### PR TITLE
Register SteamAudioServer before initializing it to remove an error.

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -31,8 +31,8 @@ void init_ext(ModuleInitializationLevel p_level) {
 	}
 
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
-		auto sa = memnew(SteamAudioServer);
 		GDREGISTER_CLASS(SteamAudioServer);
+		auto sa = memnew(SteamAudioServer);
 	}
 }
 


### PR DESCRIPTION
(closes #7)