### PR TITLE
Skip source simulation when we know it's not playing anything.

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -38,6 +38,10 @@ void SteamAudioServer::tick() {
 					"local state has empty player, not updating simulation state");
 		}
 
+		if (!ls->src.player->is_playing()) {
+			continue; // it's pointless to simulate streams that aren't active
+		}
+
 		Vector3 src_pos = ls->src.player->get_global_position();
 		ls->dir_to_listener = src_pos - self->listener->get_global_position();
 

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -3,6 +3,7 @@
 
 #include "godot_cpp/variant/transform3d.hpp"
 #include <phonon.h>
+#include <godot_cpp/classes/audio_stream_player3d.hpp>
 #include <godot_cpp/classes/node3d.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <mutex>
@@ -34,7 +35,7 @@ struct GlobalSteamAudioState {
 };
 
 struct SteamAudioSource {
-	Node3D *player;
+	AudioStreamPlayer3D *player;
 	IPLSource src;
 };
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -146,7 +146,7 @@ void SteamAudioStreamPlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_parent", "node"), &SteamAudioStreamPlayback::set_parent);
 }
 
-void SteamAudioStreamPlayback::set_parent(Node3D *node) {
+void SteamAudioStreamPlayback::set_parent(AudioStreamPlayer3D *node) {
 	this->local_state.src.player = node;
 }
 

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -1,6 +1,7 @@
 #ifndef STEAM_AUDIO_STREAM_H
 #define STEAM_AUDIO_STREAM_H
 
+#include "godot_cpp/classes/audio_stream_player3d.hpp"
 #include "godot_cpp/classes/node3d.hpp"
 #include "godot_cpp/classes/ref.hpp"
 #include "steam_audio.hpp"
@@ -48,7 +49,7 @@ public:
 	SteamAudioStreamPlayback();
 	~SteamAudioStreamPlayback();
 
-	void set_parent(Node3D *node);
+	void set_parent(AudioStreamPlayer3D *node);
 	void set_cfg(SteamAudioSourceConfig cfg);
 
 	virtual int32_t _mix(AudioFrame *buffer, double rate_scale,


### PR DESCRIPTION
Can probably make some perf difference on a scene with a lot of e.g. guards that only actually play sound once in a while.