### PR TITLE
Skip source simulation when we know it's not playing anything.

### DIFF
--- a/project/src/random_pluck.gd
+++ b/project/src/random_pluck.gd
@@ -2,7 +2,13 @@ extends SteamAudioPlayer
 
 @export var anim: AnimationPlayer
 
-func _process(_delta):
+var timeout := 0.0
+
+func _process(delta):
 	if !is_playing():
-		play()
-		anim.play("fade")
+		timeout -= delta 
+
+		if timeout < 0:
+			play()
+			anim.play("fade")
+			timeout = 0.5

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -37,6 +37,9 @@ void SteamAudioServer::tick() {
 			UtilityFunctions::push_warning(
 					"local state has empty player, not updating simulation state");
 		}
+		if (!ls->src.player->is_playing()) {
+			continue;
+		}
 
 		Vector3 src_pos = ls->src.player->get_global_position();
 		ls->dir_to_listener = src_pos - self->listener->get_global_position();
@@ -78,6 +81,14 @@ void SteamAudioServer::tick() {
 	SteamAudio::log(SteamAudio::log_debug, "tick: direct sim complete");
 
 	for (auto ls : self->local_states) {
+		if (ls->src.player == nullptr) {
+			UtilityFunctions::push_warning(
+					"local state has empty player, not updating simulation state");
+		}
+		if (!ls->src.player->is_playing()) {
+			continue;
+		}
+
 		IPLSimulationOutputs outputs{};
 		iplSourceGetOutputs(ls->src.src, IPL_SIMULATIONFLAGS_DIRECT, &outputs);
 		ls->direct_outputs = outputs.direct;
@@ -90,6 +101,14 @@ void SteamAudioServer::tick() {
 
 	global_state.refl_ir_lock.lock();
 	for (auto ls : local_states) {
+		if (ls->src.player == nullptr) {
+			UtilityFunctions::push_warning(
+					"local state has empty player, not updating simulation state");
+		}
+		if (!ls->src.player->is_playing()) {
+			continue;
+		}
+
 		IPLSimulationOutputs outputs;
 		iplSourceGetOutputs(ls->src.src, IPL_SIMULATIONFLAGS_REFLECTIONS, &outputs);
 		ls->refl_outputs = outputs.reflections;
@@ -97,6 +116,14 @@ void SteamAudioServer::tick() {
 	global_state.refl_ir_lock.unlock();
 
 	for (auto ls : self->local_states) {
+		if (ls->src.player == nullptr) {
+			UtilityFunctions::push_warning(
+					"local state has empty player, not updating simulation state");
+		}
+		if (!ls->src.player->is_playing()) {
+			continue;
+		}
+
 		Vector3 src_pos = ls->src.player->get_global_position();
 		IPLCoordinateSpace3 src_coords;
 		src_coords.ahead = IPLVector3{};

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -3,6 +3,7 @@
 
 #include "godot_cpp/variant/transform3d.hpp"
 #include <phonon.h>
+#include <godot_cpp/classes/audio_stream_player3d.hpp>
 #include <godot_cpp/classes/node3d.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <mutex>
@@ -34,7 +35,7 @@ struct GlobalSteamAudioState {
 };
 
 struct SteamAudioSource {
-	Node3D *player = nullptr;
+	AudioStreamPlayer3D *player = nullptr;
 	IPLSource src;
 };
 


### PR DESCRIPTION
#12 did not make any sense until #16 got merged. Now that the local state and its source are inside StreamPlayer then we know it's pointless to simulate the source when the StreamPlayer isn't playing any sound.