### PR TITLE
Major polish.

### DIFF
--- a/project/scenes/demo.tscn
+++ b/project/scenes/demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=38 format=3 uid="uid://bilxmr83dwsgw"]
+[gd_scene load_steps=36 format=3 uid="uid://bilxmr83dwsgw"]
 
 [ext_resource type="Script" path="res://src/player.gd" id="1_c2adp"]
 [ext_resource type="SteamAudioMaterial" uid="uid://dbai50r63k346" path="res://addons/steamaudio/materials/rock_material.tres" id="1_wtcfy"]
@@ -33,8 +33,6 @@ data = PackedVector3Array(1, 0, 1, -1, 0, 1, 1, 0, -1, -1, 0, 1, -1, 0, -1, 1, 0
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_j0ktp"]
 
-[sub_resource type="SteamAudioStream" id="SteamAudioStream_vraar"]
-
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_dg8l6"]
 albedo_color = Color(0.976471, 0.133333, 0.286275, 1)
 emission_enabled = true
@@ -49,8 +47,6 @@ stream_0/stream = ExtResource("5_00edw")
 stream_0/weight = 1.0
 stream_1/stream = ExtResource("6_dw5dv")
 stream_1/weight = 1.0
-
-[sub_resource type="SteamAudioStream" id="SteamAudioStream_fkje5"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pyn86"]
 albedo_color = Color(0.976471, 0.133333, 0.286275, 1)
@@ -201,7 +197,7 @@ sub_stream = ExtResource("3_0iivb")
 loop_sub_stream = true
 reflection = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0.0999999)
-stream = SubResource("SteamAudioStream_vraar")
+stream = ExtResource("3_0iivb")
 volume_db = 20.0
 autoplay = true
 panning_strength = 0.0
@@ -226,7 +222,7 @@ sub_stream = SubResource("AudioStreamRandomizer_w72gs")
 min_attenuation_distance = 5.0
 reflection = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
-stream = SubResource("SteamAudioStream_fkje5")
+stream = SubResource("AudioStreamRandomizer_w72gs")
 volume_db = 20.0
 panning_strength = 0.0
 script = ExtResource("7_gx8pe")
@@ -298,7 +294,7 @@ distance_attenuation = true
 min_attenuation_distance = 5.0
 reflection = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0.0999999)
-stream = SubResource("SteamAudioStream_vraar")
+stream = ExtResource("3_0iivb")
 attenuation_model = 3
 volume_db = 20.0
 autoplay = true
@@ -324,7 +320,7 @@ sub_stream = ExtResource("3_0iivb")
 loop_sub_stream = true
 min_attenuation_distance = 5.0
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 1, 1)
-stream = SubResource("SteamAudioStream_vraar")
+stream = ExtResource("3_0iivb")
 volume_db = 20.0
 autoplay = true
 panning_strength = 0.0

--- a/project/scenes/demo.tscn
+++ b/project/scenes/demo.tscn
@@ -199,14 +199,13 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.6, 0)
 [node name="SteamAudioPlayer" type="SteamAudioPlayer" parent="Wooden House"]
 sub_stream = ExtResource("3_0iivb")
 loop_sub_stream = true
-min_attenuation_distance = 5.0
 reflection = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0.0999999)
 stream = SubResource("SteamAudioStream_vraar")
-attenuation_model = 3
 volume_db = 20.0
 autoplay = true
 panning_strength = 0.0
+metadata/_edit_group_ = true
 
 [node name="OmniLight3D" type="OmniLight3D" parent="Wooden House/SteamAudioPlayer"]
 light_energy = 2.0
@@ -228,11 +227,11 @@ min_attenuation_distance = 5.0
 reflection = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 stream = SubResource("SteamAudioStream_fkje5")
-attenuation_model = 3
 volume_db = 20.0
 panning_strength = 0.0
 script = ExtResource("7_gx8pe")
 anim = NodePath("AnimationPlayer")
+metadata/_edit_group_ = true
 
 [node name="OmniLight3D" type="OmniLight3D" parent="Wooden House with RandomStream/Pluck Randomizer"]
 light_energy = 2.0
@@ -295,6 +294,7 @@ material = ExtResource("6_ph4pe")
 [node name="SteamAudioPlayer" type="SteamAudioPlayer" parent="Carpet House"]
 sub_stream = ExtResource("3_0iivb")
 loop_sub_stream = true
+distance_attenuation = true
 min_attenuation_distance = 5.0
 reflection = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0.0999999)
@@ -303,6 +303,7 @@ attenuation_model = 3
 volume_db = 20.0
 autoplay = true
 panning_strength = 0.0
+metadata/_edit_group_ = true
 
 [node name="OmniLight3D" type="OmniLight3D" parent="Carpet House/SteamAudioPlayer"]
 light_energy = 2.0
@@ -324,10 +325,10 @@ loop_sub_stream = true
 min_attenuation_distance = 5.0
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 1, 1)
 stream = SubResource("SteamAudioStream_vraar")
-attenuation_model = 3
 volume_db = 20.0
 autoplay = true
 panning_strength = 0.0
+metadata/_edit_group_ = true
 
 [node name="OmniLight3D" type="OmniLight3D" parent="Collider Test/SteamAudioPlayer3"]
 light_energy = 2.0

--- a/project/sound/2.mp3.import
+++ b/project/sound/2.mp3.import
@@ -12,7 +12,7 @@ dest_files=["res://.godot/imported/2.mp3-3055b0866e8cbdb3783e580633ac5a8a.mp3str
 
 [params]
 
-loop=false
+loop=true
 loop_offset=0
 bpm=0
 beat_count=0

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -17,7 +17,6 @@
 #include "phonon.h"
 #include "server.hpp"
 #include "steam_audio.hpp"
-#include <numeric>
 
 void SteamAudioGeometry::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_material"), &SteamAudioGeometry::get_material);
@@ -106,7 +105,7 @@ void SteamAudioGeometry::create_meshes_from_mesh_inst_3d(MeshInstance3D *mesh_in
 	for (int i = 0; i < mesh->get_surface_count(); i++) {
 		auto ipl_mesh = ipl_mesh_to_godot_mesh(mesh, material, trf, i);
 		meshes.push_back(ipl_mesh);
-		iplStaticMeshAdd(ipl_mesh, SteamAudioServer::get_singleton()->get_global_state()->scene);
+		SteamAudioServer::get_singleton()->add_static_mesh(ipl_mesh);
 	}
 }
 

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -7,7 +7,6 @@
 #include "steam_audio.hpp"
 #include <phonon.h>
 #include <godot_cpp/classes/audio_stream_player3d.hpp>
-#include <optional>
 
 using namespace godot;
 
@@ -24,7 +23,8 @@ private:
 		16,
 		0.0f,
 		1,
-		true,
+		10000.0f,
+		false,
 		true,
 		true,
 		false
@@ -60,6 +60,8 @@ public:
 	void set_min_attenuation_dist(float p_min_attenuation_dist);
 	int get_ambisonics_order();
 	void set_ambisonics_order(int p_ambisonics_order);
+	float get_max_reflection_dist();
+	void set_max_reflection_dist(float p_max_reflection_dist);
 
 	bool get_loop_sub_stream();
 	void set_loop_sub_stream(bool p_loop_sub_stream);

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -27,6 +27,8 @@ private:
 	std::mutex refl_mux;
 	std::condition_variable cv;
 
+	std::vector<IPLStaticMesh> meshes_to_add;
+
 	// TODO: allow for multiple
 	SteamAudioListener *listener;
 
@@ -48,6 +50,7 @@ public:
 	void add_listener(SteamAudioListener *listener);
 	void add_local_state(LocalSteamAudioState *ls);
 	void remove_local_state(LocalSteamAudioState *ls);
+	void add_static_mesh(IPLStaticMesh mesh);
 
 	void tick();
 };

--- a/src/server_init.cpp
+++ b/src/server_init.cpp
@@ -81,6 +81,12 @@ IPLSceneSettings create_scene_cfg(IPLContext ctx) {
 		handleErr(err);
 		scene_cfg.embreeDevice = embree_dev;
 	}
+	scene_cfg.closestHitCallback = nullptr;
+	scene_cfg.anyHitCallback = nullptr;
+	scene_cfg.batchedClosestHitCallback = nullptr;
+	scene_cfg.batchedAnyHitCallback = nullptr;
+	scene_cfg.userData = nullptr;
+	scene_cfg.radeonRaysDevice = nullptr;
 	return scene_cfg;
 }
 

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -45,6 +45,7 @@ struct SteamAudioSourceConfig {
 	int transm_rays;
 	float min_attn_dist;
 	int ambisonics_order;
+	float max_refl_dist;
 	bool is_dist_attn_on;
 	bool is_ambisonics_on;
 	bool is_occlusion_on;


### PR DESCRIPTION
SteamAudioPlayer will always have a set SteamAudioStream.
SteamAudioPlayer now uses Godot's built-in distance attenuation by
default.
There is now a maximum reflection distance which can be customized, if
an audio player's distance to SteamAudioListener is higher than that
then the reflection simulation will not run.
Fixed a crash that happens when SteamAudioGeometry is above
SteamAudioConfig in the scene.
Remove the need for a sub_stream.