### PR TITLE
Add some useful methods in SteamAudioPlayer.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -18,7 +18,7 @@ IPLSceneType SteamAudioConfig::scene_type = IPL_SCENETYPE_EMBREE; // TODO: suppo
 void SteamAudioConfig::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_global_log_level"), &SteamAudioConfig::get_global_log_level);
 	ClassDB::bind_method(D_METHOD("set_global_log_level", "p_global_log_level"), &SteamAudioConfig::set_global_log_level);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "global_log_level", PROPERTY_HINT_ENUM, "Debug,Info,Error"), "set_global_log_level", "get_global_log_level");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "global_log_level", PROPERTY_HINT_ENUM, "Debug,Info,Warning,Error"), "set_global_log_level", "get_global_log_level");
 
 	ADD_GROUP("Performance", "");
 	ClassDB::bind_method(D_METHOD("get_scene_type"), &SteamAudioConfig::get_scene_type);

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -71,6 +71,9 @@ public:
 	bool is_occlusion_on();
 	void set_occlusion_on(bool p_occlusion_on);
 
+	void play_stream(const Ref<AudioStream> &p_stream, float p_from_offset, float p_volume_db, float p_pitch_scale);
+	Ref<AudioStream> get_inner_stream();
+
 	PackedStringArray _get_configuration_warnings() const override;
 };
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -163,13 +163,6 @@ void SteamAudioServer::tick() {
 	SteamAudio::log(SteamAudio::log_debug, "tick: done");
 }
 
-void SteamAudioServer::init_scene(IPLSceneSettings *scene_cfg) {
-	SteamAudio::log(SteamAudio::log_info, "Initializing SteamAudioServer scene");
-	IPLerror err = iplSceneCreate(global_state.ctx, scene_cfg, &global_state.scene);
-	handleErr(err);
-	global_state.scene = iplSceneRetain(global_state.scene);
-}
-
 GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
 	self->init_mux.lock();
 	if (self->is_global_state_init.load()) {
@@ -188,7 +181,10 @@ GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
 	global_state.ctx = create_ctx();
 
 	IPLSceneSettings scene_cfg = create_scene_cfg(global_state.ctx);
-	init_scene(&scene_cfg);
+	SteamAudio::log(SteamAudio::log_info, "Initializing SteamAudioServer scene");
+	IPLerror err = iplSceneCreate(global_state.ctx, &scene_cfg, &global_state.scene);
+	handleErr(err);
+	global_state.scene = iplSceneRetain(global_state.scene);
 	for (auto m : meshes_to_add) {
 		iplStaticMeshAdd(m, global_state.scene);
 	}

--- a/src/server_init.cpp
+++ b/src/server_init.cpp
@@ -72,7 +72,7 @@ IPLSimulator create_simulator(IPLContext ctx, IPLAudioSettings audio_cfg, IPLSce
 }
 
 IPLSceneSettings create_scene_cfg(IPLContext ctx) {
-	IPLSceneSettings scene_cfg;
+	IPLSceneSettings scene_cfg = {};
 	scene_cfg.type = SteamAudioConfig::scene_type;
 	if (scene_cfg.type == IPL_SCENETYPE_EMBREE) {
 		IPLEmbreeDeviceSettings embree_cfg{};
@@ -81,12 +81,6 @@ IPLSceneSettings create_scene_cfg(IPLContext ctx) {
 		handleErr(err);
 		scene_cfg.embreeDevice = embree_dev;
 	}
-	scene_cfg.closestHitCallback = nullptr;
-	scene_cfg.anyHitCallback = nullptr;
-	scene_cfg.batchedClosestHitCallback = nullptr;
-	scene_cfg.batchedAnyHitCallback = nullptr;
-	scene_cfg.userData = nullptr;
-	scene_cfg.radeonRaysDevice = nullptr;
 	return scene_cfg;
 }
 

--- a/src/steam_audio.cpp
+++ b/src/steam_audio.cpp
@@ -7,9 +7,15 @@ void SteamAudio::log(GodotSteamAudioLogLevel lvl, const char *str) {
 		return;
 	}
 
-	if (lvl < log_error) {
-		UtilityFunctions::print("[godot-steam-audio] ", str);
-	} else {
-		UtilityFunctions::push_error("[godot-steam-audio] ", str);
+	switch (lvl) {
+		case log_error:
+			UtilityFunctions::push_error("[godot-steam-audio] ", str);
+			return;
+		case log_warn:
+			UtilityFunctions::push_warning("[godot-steam-audio] ", str);
+			return;
+		default:
+			UtilityFunctions::print("[godot-steam-audio] ", str);
+			return;
 	}
 }

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -15,6 +15,7 @@ public:
 	typedef enum {
 		log_debug,
 		log_info,
+		log_warn,
 		log_error
 	} GodotSteamAudioLogLevel;
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -24,6 +24,7 @@ Ref<AudioStreamPlayback> SteamAudioStream::_instantiate_playback() const {
 }
 
 void SteamAudioStream::set_stream(Ref<AudioStream> p_stream) { stream = p_stream; }
+Ref<AudioStream> SteamAudioStream::get_stream() { return this->stream; }
 
 // ----------------------------------------------------
 // SteamAudioStreamPlayback

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -29,6 +29,7 @@ public:
 
 	Ref<AudioStreamPlayback> _instantiate_playback() const override;
 	void set_stream(Ref<AudioStream> p_stream);
+	Ref<AudioStream> get_stream();
 
 	SteamAudioPlayer *parent;
 };


### PR DESCRIPTION
It's useful to let our users know what stream they are playing easily, and I also dislike how clunky it feels to change a stream at runtime.
[godot-steam-audio-vX.Y.Z.zip](https://github.com/stechyo/godot-steam-audio/files/14001364/godot-steam-audio-vX.Y.Z.zip)
