### PR TITLE
fix build for macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ project/addons/godot-steam-audio/bin/*.dll
 project/addons/godot-steam-audio/bin/*.ilk
 project/addons/godot-steam-audio/bin/*.exp
 project/addons/godot-steam-audio/bin/*.lib
+project/addons/godot-steam-audio/bin/*.dylib

--- a/SConstruct
+++ b/SConstruct
@@ -12,13 +12,19 @@ else:
 
 sources = Glob("src/*.cpp")
 
+steam_audio_lib_path = env.get("STEAM_AUDIO_LIB_PATH", "")
+if steam_audio_lib_path == "":
+    steam_audio_lib_path = "src/lib/steamaudio/lib"
+
 if env["platform"] == "linux":
-    env.Append(LIBPATH=["src/lib/steamaudio/lib/linux-x64"])
+    env.Append(LIBPATH=[f'{steam_audio_lib_path}/linux-x64'])
     env.Append(LIBS=["libphonon.so"])
 elif env["platform"] == "windows":
-    env.Append(LIBPATH=["src/lib/steamaudio/lib/windows-x64"])
+    env.Append(LIBPATH=[f'{steam_audio_lib_path}/windows-x64'])
     env.Append(LIBS=["phonon"])
-
+elif env["platform"] == "macos":
+    env.Append(LIBPATH=[f'{steam_audio_lib_path}/osx'])
+    env.Append(LIBS=["libphonon.dylib"])
 
 library = env.SharedLibrary(
     "project/addons/godot-steam-audio/bin/godot-steam-audio{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),

--- a/SConstruct
+++ b/SConstruct
@@ -12,9 +12,7 @@ else:
 
 sources = Glob("src/*.cpp")
 
-steam_audio_lib_path = env.get("STEAM_AUDIO_LIB_PATH", "")
-if steam_audio_lib_path == "":
-    steam_audio_lib_path = "src/lib/steamaudio/lib"
+steam_audio_lib_path = env.get("STEAM_AUDIO_LIB_PATH", "src/lib/steamaudio/lib")
 
 if env["platform"] == "linux":
     env.Append(LIBPATH=[f'{steam_audio_lib_path}/linux-x64'])

--- a/project/addons/godot-steam-audio/bin/libgodot-steam-audio.gdextension
+++ b/project/addons/godot-steam-audio/bin/libgodot-steam-audio.gdextension
@@ -11,8 +11,8 @@ linux.debug.arm64 = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.lin
 linux.release.arm64 = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.linux.template_release.arm64.so"
 windows.x86_64.debug = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.windows.template_debug.x86_64.dll"
 windows.x86_64.release = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.windows.template_release.x86_64.dll"
-macos.debug = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.macos.template_debug.framework"
-macos.release = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.macos.template_release.framework"
+macos.debug = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.macos.template_debug.universal.dylib"
+macos.release = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.macos.template_release.universal.dylib"
 
 [icons]
 


### PR DESCRIPTION
This PR makes the build on macos possible. 
Related to this issue: https://github.com/stechyo/godot-steam-audio/issues/53

It did not solved the issue with crash during scene running, but at least editor works.

Requires you to call `make install-steam-audio` or set `STEAM_AUDIO_LIB_PATH` env variable with your custom location.