### PR TITLE
Fixes for 4.3 compat, in-engine docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ project/addons/godot-steam-audio/bin/*.ilk
 project/addons/godot-steam-audio/bin/*.exp
 project/addons/godot-steam-audio/bin/*.lib
 project/addons/godot-steam-audio/bin/*.dylib
+src/gen/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src/lib/godot-cpp"]
 	path = src/lib/godot-cpp
 	url = https://github.com/stechyo/godot-cpp
-	branch = gdext/steam-audio
+	branch = 4.3-steam-audio
 [submodule "src/lib/steamaudio"]
 	path = src/lib/steamaudio
 	url = https://github.com/ValveSoftware/steam-audio

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # godot-steam-audio
 This is a GDExtension that integrates the [steam-audio](https://valvesoftware.github.io/steam-audio/) library
-into Godot 4.2. This adds sound effects such as occlusion and reverb into the engine.
+into Godot 4.3. This adds sound effects such as occlusion and reverb into the engine.
 
 ### [Demo Video](https://www.youtube.com/watch?v=vRnzfnb93Gw)
 ![A picture of the editor screen with some godot-steam-audio nodes.](doc/imgs/editor.png)

--- a/SConstruct
+++ b/SConstruct
@@ -24,6 +24,10 @@ elif env["platform"] == "macos":
     env.Append(LIBPATH=[f'{steam_audio_lib_path}/osx'])
     env.Append(LIBS=["libphonon.dylib"])
 
+if env["target"] in ["editor", "template_debug"]:
+    doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
+    sources.append(doc_data)
+
 library = env.SharedLibrary(
     "project/addons/godot-steam-audio/bin/godot-steam-audio{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
     source=sources,

--- a/doc_classes/SteamAudioConfig.xml
+++ b/doc_classes/SteamAudioConfig.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioConfig" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+		This node makes [SteamAudioServer] tick. You must have one, and only one, instance of it in your scene if you'd like the extension to do anything.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="diffuse_samples" type="int" setter="set_num_diffuse_samples" getter="get_num_diffuse_samples" default="32">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings17numDiffuseSamplesE]IPLSimulationSettings.numDiffuseSamples[/url]
+		</member>
+		<member name="global_log_level" type="int" setter="set_global_log_level" getter="get_global_log_level" enum="SteamAudio.GodotSteamAudioLogLevel" default="1">
+			The global log level for this extension. Setting it to a lower level will show more logs.
+		</member>
+		<member name="hrtf_volume" type="float" setter="set_hrtf_volume" getter="get_hrtf_volume" default="1.0">
+			Audio volume (see [url=https://valvesoftware.github.io/steam-audio/doc/capi/hrtf.html#_CPPv4N15IPLHRTFSettings6volumeE]IPLHRTFSettings.volume[/url])
+		</member>
+		<member name="max_ambisonics_order" type="int" setter="set_max_ambisonics_order" getter="get_max_ambisonics_order" default="1">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings8maxOrderE]IPLSimulationSettings.maxOrder[/url]
+		</member>
+		<member name="max_occlusion_samples" type="int" setter="set_max_num_occ_samples" getter="get_max_num_occ_samples" default="64">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings22maxNumOcclusionSamplesE]IPLSimulationSettings.maxNumOcclusionSamples[/url]
+		</member>
+		<member name="max_reflection_duration" type="float" setter="set_max_refl_duration" getter="get_max_refl_duration" default="2.0">
+            Higher values will result in more realistic reflections, but this will impact performance - see [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings11maxDurationE]IPLSimulationSettings.maxDuration[/url]
+		</member>
+		<member name="max_reflection_rays" type="int" setter="set_max_num_refl_rays" getter="get_max_num_refl_rays" default="4096">
+            Overrides each source's max_reflection_rays setting - see [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings10maxNumRaysE]IPLSimulationSettings.maxNumRays[/url]
+		</member>
+		<member name="max_reflection_sources" type="float" setter="set_max_num_refl_srcs" getter="get_max_num_refl_srcs" default="8.0">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings13maxNumSourcesE]IPLSimulationSettings.maxNumSources[/url]
+		</member>
+		<member name="reflection_threads" type="float" setter="set_num_refl_threads" getter="get_num_refl_threads" default="2.0">
+            Number of threads that reflection simulation will use (see [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N21IPLSimulationSettings10numThreadsE]IPLSimulationSettings.numThreads[/url])
+		</member>
+		<member name="scene_type" type="int" setter="set_scene_type" getter="get_scene_type" enum="IPLSceneType" default="1">
+            The ray tracing implementation to use - see [url=https://valvesoftware.github.io/steam-audio/doc/capi/scene.html#_CPPv412IPLSceneType]IPLSceneType[/url]
+		</member>
+	</members>
+</class>

--- a/doc_classes/SteamAudioDynamicGeometry.xml
+++ b/doc_classes/SteamAudioDynamicGeometry.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioDynamicGeometry" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Dynamic geometry that will affect SteamAudio simulation.
+	</brief_description>
+	<description>
+        This node will attempt to get a mesh from its parent at [code]_ready()[/code] and add it to the internal SteamAudio scene. Adding a node after the game has started probably works, but it is not supported. If this object isn't going to move, then just use [SteamAudioGeometry].
+
+		This node can extract meshes from the following nodes:
+		- [MeshInstance3D]
+		- [CollisionShape3D], [b]if its shape is one of[/b]:
+			- [BoxShape3D]
+			- [CylinderShape3D]
+			- [CapsuleShape3D]
+			- [SphereShape3D]
+			- [ConcavePolygonShape3D]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="recalculate">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="material" type="SteamAudioMaterial" setter="set_material" getter="get_material">
+			The geometry's material.
+		</member>
+	</members>
+</class>

--- a/doc_classes/SteamAudioGeometry.xml
+++ b/doc_classes/SteamAudioGeometry.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioGeometry" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Static geometry that will affect SteamAudio simulation.
+	</brief_description>
+	<description>
+        This node will attempt to get a mesh from its parent at [code]_ready()[/code] and add it to the internal SteamAudio scene. Adding a node after the game has started probably works, but it is not supported. If you want to move this node's transform at runtime, use [code]recalculate()[/code] or consider (if you want more detailed simulation and don't mind worse performance) [SteamAudioDynamicGeometry].
+		This node can extract meshes from the following nodes:
+		- [MeshInstance3D]
+		- [CollisionShape3D], [b]if its shape is one of[/b]:
+			- [BoxShape3D]
+			- [CylinderShape3D]
+			- [CapsuleShape3D]
+			- [SphereShape3D]
+			- [ConcavePolygonShape3D]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="recalculate">
+			<return type="void" />
+			<description>
+                Changes the internal SteamAudio scene to reflect any changes in transform that you may have made to the object. If you plan on calling this every frame to account for an object's motion, it's probably better to use [SteamAudioDynamicGeometry].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
+			Whether the geometry is disabled.
+		</member>
+		<member name="material" type="SteamAudioMaterial" setter="set_material" getter="get_material">
+			The geometry's material.
+		</member>
+	</members>
+</class>

--- a/doc_classes/SteamAudioListener.xml
+++ b/doc_classes/SteamAudioListener.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioListener" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		This node's transform is used for simulating the listener's transform in the SteamAudio simulation. You'll likely want to have this as a child of your [Camera3D].
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="irradiance_min_distance" type="float" setter="set_irradiance_min_dist" getter="get_irradiance_min_dist" default="1.0">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N25IPLSimulationSharedInputs21irradianceMinDistanceE]IPLSimulationSharedInputs.irradianceMinDistance[/url]
+		</member>
+		<member name="reflection_ambisonics_order" type="int" setter="set_refl_ambisonics_order" getter="get_refl_ambisonics_order" default="1">
+			May be overriden by [SteamAudioConfig] - see [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N25IPLSimulationSharedInputs5orderE]IPLSimulationSharedInputs.order[/url]
+		</member>
+		<member name="reflection_bounces" type="int" setter="set_num_refl_bounces" getter="get_num_refl_bounces" default="16">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N25IPLSimulationSharedInputs10numBouncesE]IPLSimulationSharedInputs.numBounces[/url]
+		</member>
+		<member name="reflection_duration" type="float" setter="set_refl_duration" getter="get_refl_duration" default="2.0">
+			May be overriden by [SteamAudioConfig] - see [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N25IPLSimulationSharedInputs8durationE]IPLSimulationSharedInputs.duration[/url]
+		</member>
+		<member name="reflection_rays" type="int" setter="set_num_refl_rays" getter="get_num_refl_rays" default="4096">
+			May be overriden by [SteamAudioConfig] - see [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N25IPLSimulationSharedInputs7numRaysE]IPLSimulationSharedInputs.numRays[/url]
+		</member>
+	</members>
+</class>

--- a/doc_classes/SteamAudioMaterial.xml
+++ b/doc_classes/SteamAudioMaterial.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioMaterial" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		The acoustic properties of a surface.
+	</brief_description>
+	<description>
+		This resource is a Godot translation of [url=https://valvesoftware.github.io/steam-audio/doc/capi/scene.html?highlight=iplmaterial#_CPPv411IPLMaterial]IPLMaterial[/url]. Low, middle, and high refer to frequency bands with center frequencies of 400Hz, 2.5kHz and 15kHz.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="absorption_high" type="float" setter="set_absorption_high" getter="get_absorption_high" default="0.0">
+			Fraction of sound energy absorbed at high frequencies.
+		</member>
+		<member name="absorption_low" type="float" setter="set_absorption_low" getter="get_absorption_low" default="0.0">
+			Fraction of sound energy absorbed at low frequencies.
+		</member>
+		<member name="absorption_mid" type="float" setter="set_absorption_mid" getter="get_absorption_mid" default="0.0">
+			Fraction of sound energy absorbed at mid frequencies.
+		</member>
+		<member name="scattering" type="float" setter="set_scattering" getter="get_scattering" default="0.0">
+			Fraction of sound energy scattered in a random direction when reflecting.
+		</member>
+		<member name="transmission_high" type="float" setter="set_transmission_high" getter="get_transmission_high" default="0.0">
+			Fraction of sound energy absorbed at high frequencies.
+		</member>
+		<member name="transmission_low" type="float" setter="set_transmission_low" getter="get_transmission_low" default="0.0">
+			Fraction of sound energy absorbed at low frequencies.
+		</member>
+		<member name="transmission_mid" type="float" setter="set_transmission_mid" getter="get_transmission_mid" default="0.0">
+			Fraction of sound energy absorbed at mid frequencies.
+		</member>
+	</members>
+</class>

--- a/doc_classes/SteamAudioPlayer.xml
+++ b/doc_classes/SteamAudioPlayer.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioPlayer" inherits="AudioStreamPlayer3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		This player's transform is used as the audio source transform in the SteamAudio simulation.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_inner_stream">
+			<return type="AudioStream" />
+			<description>
+				Returns the player's inner [AudioStream]
+			</description>
+		</method>
+		<method name="get_inner_stream_playback">
+			<return type="AudioStreamPlayback" />
+			<description>
+				Returns the player's inner [AudioStreamPlayback]
+			</description>
+		</method>
+		<method name="play_stream">
+			<return type="void" />
+			<param index="0" name="stream" type="AudioStream" />
+			<param index="1" name="from_offset" type="float" default="0" />
+			<param index="2" name="volume_db" type="float" default="0" />
+			<param index="3" name="pitch_scale" type="float" default="1.0" />
+			<description>
+				Plays the given stream starting at from_offset, at the defined volume and pitch scale.
+            [b]A very important note[/b]: play_stream is what you want to use if you'd like to change a SteamAudioPlayer's stream at runtime. Do not try to set the player's stream directly through set_stream, as that will disable all SteamAudio effects for that player. At runtime, the stream you've configured will be replaced with a [SteamAudioStream]. This stream has an inner stream which corresponds to what you configured in the scene.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="ambisonics_order" type="int" setter="set_ambisonics_order" getter="get_ambisonics_order" default="1">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/ambisonics-encode-effect.html#_CPPv4N31IPLAmbisonicsEncodeEffectParams5orderE]IPLAmbisonicsEncodeEffectParams.order[/url].
+		</member>
+		<member name="distance_attenuation" type="bool" setter="set_dist_attn_on" getter="is_dist_attn_on" default="false">
+            Whether SteamAudio distance attenuation is enabled. Keep in mind that this is disabled by default, and enabling it will disable Godot's built-in attenuation, which you can only re-enable when you disable this.
+		</member>
+		<member name="max_reflection_distance" type="float" setter="set_max_reflection_distance" getter="get_max_reflection_distance" default="10000.0">
+            The maximum distance from the listener at which reflection simulation is run for this audio source. Keep in mind that this does not disable reflection if it has already been simulated, it just doesn't update the effect.
+		</member>
+		<member name="min_attenuation_distance" type="float" setter="set_min_attenuation_distance" getter="get_min_attenuation_distance" default="0.0">
+            See
+            [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N27IPLDistanceAttenuationModel11minDistanceE]IPLDistanceAttenuationModel.minDistance[/url], and note the distance attenuation type in godot-steam-audio is always [code]IPL_DISTANCEATTENUATIONTYPE_INVERSEDISTANCE[/code].
+		</member>
+		<member name="occlusion" type="bool" setter="set_occlusion_on" getter="is_occlusion_on" default="true">
+			Whether SteamAudio occlusion and transmission is enabled.
+		</member>
+		<member name="occlusion_radius" type="float" setter="set_occlusion_radius" getter="get_occlusion_radius" default="4.0">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N19IPLSimulationInputs15occlusionRadiusE]IPLSimulationInputs.occlusionRadius[/url].
+		</member>
+		<member name="occlusion_samples" type="int" setter="set_occlusion_samples" getter="get_occlusion_samples" default="32">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N19IPLSimulationInputs19numOcclusionSamplesE]IPLSimulationInputs.numOcclusionSamples.
+		</member>
+		<member name="reflection" type="bool" setter="set_reflection_on" getter="is_reflection_on" default="false">
+			Whether SteamAudio reflection is on.
+		</member>
+		<member name="transmission_rays" type="int" setter="set_transmission_rays" getter="get_transmission_rays" default="16">
+			See [url=https://valvesoftware.github.io/steam-audio/doc/capi/simulation.html#_CPPv4N19IPLSimulationInputs19numTransmissionRaysE]IPLSimulationInputs.numTransmissionRays[/url].
+		</member>
+	</members>
+</class>

--- a/doc_classes/SteamAudioServer.xml
+++ b/doc_classes/SteamAudioServer.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioServer" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		This is a singleton that handles all SteamAudio global state. You should not interact with it directly.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_singleton" qualifiers="static">
+			<return type="SteamAudioServer" />
+			<description>
+			</description>
+		</method>
+		<method name="tick">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/SteamAudioStream.xml
+++ b/doc_classes/SteamAudioStream.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioStream" inherits="AudioStream" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+        You do not need to, and [b]should not[/b] assign this stream to your [SteamAudioPlayer], as the extension handles that for you.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc_classes/SteamAudioStreamPlayback.xml
+++ b/doc_classes/SteamAudioStreamPlayback.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SteamAudioStreamPlayback" inherits="AudioStreamPlayback" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+        This playback will contain an audio stream that you provided when configuring your Godot scene, and it will apply the SteamAudio effects configured in the corresponding [SteamAudioPlayer] to it.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="play_stream">
+			<return type="int" />
+			<param index="0" name="stream" type="AudioStream" />
+			<param index="1" name="from_offset" type="float" default="0" />
+			<param index="2" name="volume_db" type="float" default="0" />
+			<param index="3" name="pitch_scale" type="float" default="1.0" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/project/addons/godot-steam-audio/bin/libgodot-steam-audio.gdextension
+++ b/project/addons/godot-steam-audio/bin/libgodot-steam-audio.gdextension
@@ -1,14 +1,12 @@
 [configuration]
 
 entry_symbol = "init_extension"
-compatibility_minimum = 4.2
+compatibility_minimum = 4.3
 
 [libraries]
 
 linux.x86_64.debug ="res://addons/godot-steam-audio/bin/libgodot-steam-audio.linux.template_debug.x86_64.so"
 linux.x86_64.release = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.linux.template_release.x86_64.so"
-linux.debug.arm64 = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.linux.template_debug.arm64.so"
-linux.release.arm64 = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.linux.template_release.arm64.so"
 windows.x86_64.debug = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.windows.template_debug.x86_64.dll"
 windows.x86_64.release = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.windows.template_release.x86_64.dll"
 macos.debug = "res://addons/godot-steam-audio/bin/libgodot-steam-audio.macos.template_debug.universal.dylib"

--- a/project/project.godot
+++ b/project/project.godot
@@ -12,50 +12,50 @@ config_version=5
 
 config/name="Godot-SteamAudio Demo"
 run/main_scene="res://scenes/demo.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.svg"
 
 [input]
 
 ui_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 ]
 }
 ui_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 ]
 }
 ui_up={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
 ]
 }
 ui_down={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 ]
 }
 toggle_door={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"location":0,"echo":false,"script":null)
 ]
 }
 move_door={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":50,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":50,"location":0,"echo":false,"script":null)
 ]
 }

--- a/project/scenes/demo.tscn
+++ b/project/scenes/demo.tscn
@@ -46,9 +46,7 @@ material = SubResource("StandardMaterial3D_dg8l6")
 [sub_resource type="AudioStreamRandomizer" id="AudioStreamRandomizer_w72gs"]
 streams_count = 2
 stream_0/stream = ExtResource("5_00edw")
-stream_0/weight = 1.0
 stream_1/stream = ExtResource("6_dw5dv")
-stream_1/weight = 1.0
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pyn86"]
 albedo_color = Color(0.976471, 0.133333, 0.286275, 1)

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -3,6 +3,7 @@
 #include "config.hpp"
 #include "geometry.hpp"
 #include "geometry_dynamic.hpp"
+#include "godot_cpp/core/memory.hpp"
 #include "listener.hpp"
 #include "material.hpp"
 #include "player.hpp"
@@ -15,6 +16,8 @@
 #include <godot_cpp/godot.hpp>
 
 using namespace godot;
+
+SteamAudioServer *srv;
 
 void init_ext(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE && p_level != MODULE_INITIALIZATION_LEVEL_SERVERS) {
@@ -34,13 +37,15 @@ void init_ext(ModuleInitializationLevel p_level) {
 
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
 		GDREGISTER_CLASS(SteamAudioServer);
-		auto sa = memnew(SteamAudioServer);
+		srv = memnew(SteamAudioServer);
 	}
 }
 
 void uninit_ext(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE && p_level != MODULE_INITIALIZATION_LEVEL_SERVERS) {
-		return;
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
+		// Should call this to not leak, but thread->wait_for_finish() crashes...
+		// the program is exiting anyway so I'm not too concerned
+		// memdelete(srv);
 	}
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2,6 +2,7 @@
 #include "godot_cpp/classes/engine.hpp"
 #include "godot_cpp/classes/project_settings.hpp"
 #include "godot_cpp/core/class_db.hpp"
+#include "godot_cpp/core/memory.hpp"
 #include "godot_cpp/variant/callable_method_pointer.hpp"
 #include "phonon.h"
 #include "server_init.hpp"
@@ -208,7 +209,7 @@ GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
 }
 
 void SteamAudioServer::start_refl_sim() {
-	refl_thread.start(callable_mp(this, &SteamAudioServer::run_refl_sim));
+	refl_thread->start(callable_mp(this, &SteamAudioServer::run_refl_sim));
 }
 
 void SteamAudioServer::run_refl_sim() {
@@ -290,11 +291,13 @@ SteamAudioServer::SteamAudioServer() {
 	is_refl_thread_processing.store(false);
 	is_running.store(true);
 	local_states_have_changed.store(false);
+	refl_thread = memnew(Thread);
 }
 
 SteamAudioServer::~SteamAudioServer() {
 	is_running.store(false);
-	refl_thread.wait_to_finish();
+	refl_thread->wait_to_finish();
+	memdelete(refl_thread);
 
 	if (!self->is_global_state_init.load()) {
 		return;

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -32,12 +32,12 @@ private:
 	std::vector<IPLStaticMesh> dynamic_meshes_to_add;
 
 	// TODO: allow for multiple
-	SteamAudioListener *listener;
+	SteamAudioListener *listener = nullptr;
 
 	void init_scene(IPLSceneSettings *scene_cfg);
 	void start_refl_sim();
 	void run_refl_sim();
-	Thread refl_thread = Thread();
+	Thread *refl_thread = nullptr;
 
 protected:
 	static void _bind_methods();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -67,7 +67,7 @@ int32_t SteamAudioStreamPlayback::_mix(AudioFrame *buffer, double rate_scale, in
 		return frames;
 	}
 
-	PackedVector2Array mixed_frames = stream_playback->get_raw_audio(rate_scale, frames);
+	PackedVector2Array mixed_frames = stream_playback->mix_audio(rate_scale, frames);
 	frames = int(mixed_frames.size());
 
 	for (int i = 0; i < frames; i++) {


### PR DESCRIPTION
Should close #66 and #2, perhaps #68. Need to test this a bit further to see if all crashes are gone.

If you'd like to test this:
1. Download the patched Godot 4.3 [release](https://github.com/stechyo/godot/releases/tag/4.3-steam-audio)
2. Download the extension from the Github Action below
[Extension only](https://github.com/stechyo/godot-steam-audio/actions/runs/10537218694/artifacts/1850071947)
[Extension + demo](https://github.com/stechyo/godot-steam-audio/actions/runs/10537218694/artifacts/1850071974)