### PR TITLE
Fix: hearing damage when all direct effects are disabled. (closes #70)

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -92,6 +92,12 @@ int32_t SteamAudioStreamPlayback::_mix(AudioFrame *buffer, double rate_scale, in
 				ls->fx.direct, &ls->direct_outputs,
 				&ls->bufs.in, &ls->bufs.direct);
 	} else {
+		for (int i = 0; i < ls->bufs.direct.numChannels; i++) {
+			for (int j = 0; j < ls->bufs.direct.numSamples; j++) {
+				ls->bufs.direct.data[i][j] = 0.0f;
+			}
+		}
+
 		iplAudioBufferMix(gs->ctx, &ls->bufs.in, &ls->bufs.direct);
 	}
 


### PR DESCRIPTION
It seems that iplAudioBufferMix doesn't clear the buffers, and doing it by hand seems to avoid weird audio.