### PR TITLE
Implement Steam Audio log callback

### DIFF
--- a/src/server_init.cpp
+++ b/src/server_init.cpp
@@ -88,6 +88,7 @@ IPLSceneSettings create_scene_cfg(IPLContext ctx) {
 IPLContext create_ctx() {
 	IPLContextSettings ctx_cfg{};
 	ctx_cfg.version = STEAMAUDIO_VERSION;
+	ctx_cfg.logCallback = log_callback;
 	IPLContext ctx;
 	IPLerror err = iplContextCreate(&ctx_cfg, &ctx);
 	handleErr(err);

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -119,4 +119,23 @@ inline void handleErr(IPLerror err) {
 	}
 }
 
+inline void log_callback(IPLLogLevel level, const char *message) {
+	SteamAudio::GodotSteamAudioLogLevel godot_log_level;
+	switch (level) {
+		case IPL_LOGLEVEL_INFO:
+			godot_log_level = SteamAudio::GodotSteamAudioLogLevel::log_info;
+			break;
+		case IPL_LOGLEVEL_WARNING:
+			godot_log_level = SteamAudio::GodotSteamAudioLogLevel::log_warn;
+			break;
+		case IPL_LOGLEVEL_ERROR:
+			godot_log_level = SteamAudio::GodotSteamAudioLogLevel::log_error;
+			break;
+		case IPL_LOGLEVEL_DEBUG:
+			godot_log_level = SteamAudio::GodotSteamAudioLogLevel::log_debug;
+			break;
+	}
+	SteamAudio::log(godot_log_level, String(message).strip_edges().utf8().get_data());
+}
+
 #endif


### PR DESCRIPTION
This fixes #73

This implements the Steam Audio context log callback and logs the messages using `SteamAudio::log` with the equivalent level for the plugin enum. 

These messages will also now appear in the editor Output panel instead of only appearing in stdout:

```
[godot-steam-audio] Initializing SteamAudioServer global state
[godot-steam-audio] Initialized Embree v2.17.07.
[godot-steam-audio] Initialized SteamAudioServer global state
```