### PR TITLE
Increase portability of Linux artifacts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The latest release doesn't work on older Linux distros because of this error:
```Error: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found```
so I set Ubuntu version to 22.04 in CI like Godot itself:
https://github.com/godotengine/godot/blob/f0f5319b0b5b56db9f8023ac4132088df9e86b9e/.github/workflows/linux_builds.yml#L17
