### PR TITLE
Fix geometry being created multiple times between tree transitions

### DIFF
--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -26,8 +26,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	bool created = false;
-	bool registered = false;
+	std::atomic<bool> created;
+	std::atomic<bool> registered;
 	bool disabled = false;
 
 	SteamAudioGeometry();

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -26,6 +26,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	bool created = false;
+	bool registered = false;
 	bool disabled = false;
 
 	SteamAudioGeometry();


### PR DESCRIPTION
Use case:
- large dynamic scene where nodes containing `SteamAudioGeometry` are added/removed from the tree at runtime (NOT freed, just removed from the tree)

Issue:
- when a `SteamAudioGeometry` node is removed from the tree and then added again, the geometry is created and registered multiple times

Fix:
- unregistered when removed from the tree
- add checks to only create/register the geometry once unless destroyed/unregistered