### PR TITLE
Fix reflection thread stopping when player is freed

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -255,7 +255,7 @@ void SteamAudioServer::run_refl_sim() {
 		if (local_states_have_changed.load()) {
 			local_states_have_changed.store(false);
 			is_refl_thread_processing.store(false);
-			return;
+			continue;
 		}
 		SteamAudio::log(SteamAudio::log_debug, "running reflection sim");
 		iplSimulatorRunReflections(global_state.sim);


### PR DESCRIPTION
Looks like it was meant to be `continue` to begin with. Currently reflections stop simulating once a player is freed