### PR TITLE
Only export entry symbol when compiling for Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,6 +17,7 @@ steam_audio_lib_path = env.get("STEAM_AUDIO_LIB_PATH", "src/lib/steamaudio/lib")
 if env["platform"] == "linux":
     env.Append(LIBPATH=[f'{steam_audio_lib_path}/linux-x64'])
     env.Append(LIBS=["libphonon.so"])
+    env.Append(LINKFLAGS=["-Wl,--version-script={}".format(env.File("linux_symbols.map").abspath)])
 elif env["platform"] == "windows":
     env.Append(LIBPATH=[f'{steam_audio_lib_path}/windows-x64'])
     env.Append(LIBS=["phonon"])

--- a/linux_symbols.map
+++ b/linux_symbols.map
@@ -1,0 +1,6 @@
+{
+    global:
+        init_extension;
+    local:
+        *;
+};


### PR DESCRIPTION
This limits the exported symbols on Linux to just the entry symbol to avoid the extension exporting standard library symbols if statically linking to the standard library which can cause shared libraries used by other extensions to break.

This partially addresses #107, however if other GDExtensions are used in the same project which link the C++ standard library statically (`use_static_cpp` defaults to True in `godot-cpp` when compiling for Linux as of this set of changes https://github.com/godotengine/godot-cpp/commit/d502d8e8aae35248bad69b9f40b98150ab694774 cherry picked into the 4.4 branch in July) and do not have a similar limit on the exported symbols, unexpected crashing when `libphonon.so` attempts to access the standard library can still occur if their extension is loaded first. 

This issue provided some helpful clues as to what was going on https://github.com/godotengine/webrtc-native/issues/127 and specifically the comment https://github.com/godotengine/webrtc-native/issues/127#issuecomment-1866255336 which is the method I've used in this PR to limit the exported symbols.