### PR TITLE
Switch to default scene type when on Android

### DIFF
--- a/src/server_init.cpp
+++ b/src/server_init.cpp
@@ -81,6 +81,10 @@ IPLSceneSettings create_scene_cfg(IPLContext ctx) {
 			Engine::get_singleton()->get_architecture_name() == "arm64") {
 		SteamAudioConfig::scene_type = IPL_SCENETYPE_DEFAULT;
 		SteamAudio::log(SteamAudio::log_info, "Embree is not supported on Apple Silicon, reverting to default scene type.");
+	} else if (SteamAudioConfig::scene_type == IPL_SCENETYPE_EMBREE &&
+			OS::get_singleton()->get_name() == "Android") {
+		SteamAudioConfig::scene_type = IPL_SCENETYPE_DEFAULT;
+		SteamAudio::log(SteamAudio::log_info, "Embree is not supported on Android, reverting to default scene type.");
 	}
 
 	scene_cfg.type = SteamAudioConfig::scene_type;


### PR DESCRIPTION
Android does not support Embree, so currently a Godot SteamAudio project will crash on Android whenever starting up with a default `SteamAudioConfig`. This fixes that!