### PR TITLE
Fix macOS dependency search path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,15 @@ install-steam-audio:
 	rm src/lib/steamaudio.zip
 	cp src/lib/steamaudio/lib/linux-x64/* project/addons/godot-steam-audio/bin/
 	cp src/lib/steamaudio/lib/windows-x64/* project/addons/godot-steam-audio/bin/
+	cp src/lib/steamaudio/lib/osx/* project/addons/godot-steam-audio/bin/
 	cp src/lib/steamaudio/lib/android-armv8/* project/addons/godot-steam-audio/bin/android/arm64
 	cp src/lib/steamaudio/lib/android-x64/* project/addons/godot-steam-audio/bin/android/x86_64
 
 release:
 	scons platform=android arch=arm64 target=template_release && scons platform=android arch=x86_64 target=template_release && \
 		scons platform=android arch=arm64 target=template_debug && scons platform=android arch=x86_64 target=template_debug && \
-		scons platform=linux target=template_debug && scons platform=windows target=template_debug && \
-		scons platform=linux target=template_release && scons platform=windows target=template_release
+		scons platform=linux target=template_debug && scons platform=windows target=template_debug && scons platform=macos target=template_debug && \
+		scons platform=linux target=template_release && scons platform=windows target=template_release && scons platform=macos target=template_release
 	mkdir godot-steam-audio-demo
 	mkdir godot-steam-audio
 	cp -r ./project/* ./godot-steam-audio-demo

--- a/SConstruct
+++ b/SConstruct
@@ -37,6 +37,7 @@ elif env["platform"] == "windows":
     env.Append(LIBPATH=[f'{steam_audio_lib_path}/windows-x64'])
 elif env["platform"] == "macos":
     env.Append(LIBPATH=[f'{steam_audio_lib_path}/osx'])
+    env.Append(LINKFLAGS=['-Wl,-rpath,@loader_path'])
 elif env["platform"] == "android":
     if env["arch"] == "arm64":
         env.Append(LIBPATH=[f'{steam_audio_lib_path}/android-armv8'])

--- a/project/addons/godot-steam-audio/bin/libgodot-steam-audio.gdextension
+++ b/project/addons/godot-steam-audio/bin/libgodot-steam-audio.gdextension
@@ -44,6 +44,12 @@ linux.x86_64.debug = {
 linux.x86_64.release = {
     "res://addons/godot-steam-audio/bin/libphonon.so": ""
 }
+macos.debug = {
+    "res://addons/godot-steam-audio/bin/libphonon.dylib": ""
+}
+macos.release = {
+    "res://addons/godot-steam-audio/bin/libphonon.dylib": ""
+}
 android.x86_64.debug = {
     "res://addons/godot-steam-audio/bin/android/x86_64/libphonon.so": ""
 }


### PR DESCRIPTION
Fixes #53.

Currently on macOS, the built `.dylib` does not search its containing directory for dependencies—thus, it cannot find `libphonon.dylib` and fails to load.

This PR adds a linker flag to set the search path to `@loader_path`, which represents the library's location, allowing the dependency to be found.

The `Makefile` and `.gdextension` have also been updated to include files for macOS.