### PR TITLE
Use Godot thread for reflection handling

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -240,6 +240,7 @@ GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
 }
 
 void SteamAudioServer::start_refl_sim() {
+	refl_thread.instantiate();
 	refl_thread->start(callable_mp(this, &SteamAudioServer::run_refl_sim));
 }
 
@@ -322,13 +323,12 @@ SteamAudioServer::SteamAudioServer() {
 	is_refl_thread_processing.store(false);
 	is_running.store(true);
 	local_states_have_changed.store(false);
-	refl_thread = memnew(Thread);
 }
 
 SteamAudioServer::~SteamAudioServer() {
 	is_running.store(false);
 	refl_thread->wait_to_finish();
-	memdelete(refl_thread);
+	refl_thread.unref();
 
 	if (!self->is_global_state_init.load()) {
 		return;

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -37,7 +37,7 @@ private:
 	void init_scene(IPLSceneSettings *scene_cfg);
 	void start_refl_sim();
 	void run_refl_sim();
-	Thread *refl_thread = nullptr;
+	Ref<Thread> refl_thread;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
resolves #104 and instantiate thread only when reflection worker is actually needed. I could also imagine that instantiating the thread nevertheless in the constructor. 

Godot complained sometimes on exported build that it couldn't cleanup some refs. This should also resolve this issue.