### PR TITLE
baked reflections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,12 @@ jobs:
         id: vars
         run: |
           echo "COMMIT_SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r23c
+          add-to-path: true
+          link-to-sdk: true
       - uses: actions/setup-python@v5
       - name: install-deps
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ project/addons/godot-steam-audio/bin/*.dylib
 project/addons/godot-steam-audio/bin/android/arm64/libphonon.so
 project/addons/godot-steam-audio/bin/android/x86_64/libphonon.so
 src/gen/*
+godot-steam-audio-demo/
+godot-steam-audio/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ don't have the time nor the money to support that, sorry.
 ### Getting started
 Check [Installation](https://github.com/stechyo/godot-steam-audio/wiki/Installation) for how to install the extension, [Project setup](https://github.com/stechyo/godot-steam-audio/wiki/Project-setup) for how to integrate it with your project, and [Contributing](https://github.com/stechyo/godot-steam-audio/wiki/Contributing) if you're interested in improving the extension.
 
+### Triggering a reflections bake in a scene
+You can bake reflections for a scene using the SteamAudioBakedReflections node and a small GDScript. This precomputes reflection data into a Resource that can be saved and reused.
+
+Steps:
+- Add a SteamAudioBakedReflections node to your scene.
+- Optionally add one or more SteamAudioProbe child nodes, or set the probe generation properties on the baker (probe_spacing, probe_height, probe_generation_extents) so it auto-generates probes.
+- Create or assign a SteamAudioBakedReflectionData resource to the baker’s baked_data property. This resource will store the baked bytes so it can be saved with your project.
+- From GDScript, call start_bake() and optionally monitor progress.
+
+Notes:
+- The baked data is saved into the assigned SteamAudioBakedReflectionData resource; make sure that resource is part of your project (saved to disk) so it persists.
+- The baker will generate probes automatically based on its properties and any SteamAudioProbe nodes under it.
+
 ### Acknowledgements
 godot-steam-audio is developed by [stechyo](https://github.com/stechyo). [<img src="https://github.com/gauravghongde/social-icons/blob/master/SVG/Color/Twitter.svg" width=14/>](https://twitter.com/stechyo_) [<img src="https://github.com/gauravghongde/social-icons/blob/master/SVG/Color/Youtube.svg" width=14/>](https://www.youtube.com/@Stechyo/)
 Check the [contributors](https://github.com/stechyo/godot-steam-audio/graphs/contributors) for other authors.

--- a/project/addons/godot-steam-audio/plugin.cfg
+++ b/project/addons/godot-steam-audio/plugin.cfg
@@ -1,0 +1,6 @@
+[plugin]
+name="Godot Steam Audio Tools"
+description="Adds an editor Bake button for Steam Audio reflections with a modal progress window."
+author="Godot Steam Audio"
+version="1.0"
+script="src/steam_audio_editor_plugin.gd"

--- a/project/addons/godot-steam-audio/src/steam_audio_baked_reflections_gizmo.gd
+++ b/project/addons/godot-steam-audio/src/steam_audio_baked_reflections_gizmo.gd
@@ -1,0 +1,129 @@
+@tool
+extends EditorNode3DGizmoPlugin
+
+const GIZMO_COLOR := Color(0.3, 0.7, 1.0, 0.6)
+const PROBE_COLOR := Color(1.0, 0.8, 0.2, 0.8)
+const BOX_COLOR := Color(0.3, 0.7, 1.0, 0.3)
+const PROBE_RADIUS := 0.15
+
+
+func _init() -> void:
+	create_material("box_material", BOX_COLOR)
+	create_material("probe_material", PROBE_COLOR)
+	create_handle_material("handles")
+
+
+func _get_gizmo_name() -> String:
+	return "SteamAudioBakedReflections"
+
+
+func _has_gizmo(node: Node3D) -> bool:
+	return node.get_class() == "SteamAudioBakedReflections"
+
+
+func _redraw(gizmo: EditorNode3DGizmo) -> void:
+	gizmo.clear()
+	
+	var node := gizmo.get_node_3d()
+	if not node:
+		return
+	
+	# Get the probe generation extents from the node
+	var extents: Vector3 = node.get("probe_generation_extents")
+	if not extents:
+		return
+	
+	# Draw the bounding box showing the generation volume
+	_draw_box(gizmo, extents)
+	
+	# Draw the generated probe positions
+	_draw_probes(gizmo, node)
+
+
+func _draw_box(gizmo: EditorNode3DGizmo, extents: Vector3) -> void:
+	var lines := PackedVector3Array()
+	
+	# Create box vertices at half-extents (box goes from -extents/2 to +extents/2)
+	var half_ext := extents * 0.5
+	
+	# Bottom face (Y = -half_ext.y)
+	lines.append(Vector3(-half_ext.x, -half_ext.y, -half_ext.z))
+	lines.append(Vector3(half_ext.x, -half_ext.y, -half_ext.z))
+	
+	lines.append(Vector3(half_ext.x, -half_ext.y, -half_ext.z))
+	lines.append(Vector3(half_ext.x, -half_ext.y, half_ext.z))
+	
+	lines.append(Vector3(half_ext.x, -half_ext.y, half_ext.z))
+	lines.append(Vector3(-half_ext.x, -half_ext.y, half_ext.z))
+	
+	lines.append(Vector3(-half_ext.x, -half_ext.y, half_ext.z))
+	lines.append(Vector3(-half_ext.x, -half_ext.y, -half_ext.z))
+	
+	# Top face (Y = half_ext.y)
+	lines.append(Vector3(-half_ext.x, half_ext.y, -half_ext.z))
+	lines.append(Vector3(half_ext.x, half_ext.y, -half_ext.z))
+	
+	lines.append(Vector3(half_ext.x, half_ext.y, -half_ext.z))
+	lines.append(Vector3(half_ext.x, half_ext.y, half_ext.z))
+	
+	lines.append(Vector3(half_ext.x, half_ext.y, half_ext.z))
+	lines.append(Vector3(-half_ext.x, half_ext.y, half_ext.z))
+	
+	lines.append(Vector3(-half_ext.x, half_ext.y, half_ext.z))
+	lines.append(Vector3(-half_ext.x, half_ext.y, -half_ext.z))
+	
+	# Vertical edges connecting bottom to top
+	lines.append(Vector3(-half_ext.x, -half_ext.y, -half_ext.z))
+	lines.append(Vector3(-half_ext.x, half_ext.y, -half_ext.z))
+	
+	lines.append(Vector3(half_ext.x, -half_ext.y, -half_ext.z))
+	lines.append(Vector3(half_ext.x, half_ext.y, -half_ext.z))
+	
+	lines.append(Vector3(half_ext.x, -half_ext.y, half_ext.z))
+	lines.append(Vector3(half_ext.x, half_ext.y, half_ext.z))
+	
+	lines.append(Vector3(-half_ext.x, -half_ext.y, half_ext.z))
+	lines.append(Vector3(-half_ext.x, half_ext.y, half_ext.z))
+	
+	var material := get_material("box_material", gizmo)
+	gizmo.add_lines(lines, material, false)
+
+
+func _draw_probes(gizmo: EditorNode3DGizmo, node: Node) -> void:
+	# Get probe positions from the node (already in local space)
+	var probe_positions: PackedVector3Array = node.call("get_probe_positions")
+	
+	if probe_positions.is_empty():
+		return
+	
+	var probe_material := get_material("probe_material", gizmo)
+	
+	# Draw each probe as a small sphere
+	for pos in probe_positions:
+		_draw_probe_sphere(gizmo, pos, PROBE_RADIUS, probe_material)
+
+
+func _draw_probe_sphere(gizmo: EditorNode3DGizmo, center: Vector3, radius: float, material: Material) -> void:
+	# Create a simple cross/diamond shape to represent each probe
+	var lines := PackedVector3Array()
+	
+	# X axis
+	lines.append(center + Vector3(-radius, 0, 0))
+	lines.append(center + Vector3(radius, 0, 0))
+	
+	# Y axis
+	lines.append(center + Vector3(0, -radius, 0))
+	lines.append(center + Vector3(0, radius, 0))
+	
+	# Z axis
+	lines.append(center + Vector3(0, 0, -radius))
+	lines.append(center + Vector3(0, 0, radius))
+	
+	# Diagonal crosses for better visibility
+	lines.append(center + Vector3(-radius * 0.7, -radius * 0.7, 0))
+	lines.append(center + Vector3(radius * 0.7, radius * 0.7, 0))
+	
+	lines.append(center + Vector3(-radius * 0.7, radius * 0.7, 0))
+	lines.append(center + Vector3(radius * 0.7, -radius * 0.7, 0))
+	
+	gizmo.add_lines(lines, material, false)

--- a/project/addons/godot-steam-audio/src/steam_audio_editor_plugin.gd
+++ b/project/addons/godot-steam-audio/src/steam_audio_editor_plugin.gd
@@ -1,0 +1,186 @@
+@tool
+extends EditorPlugin
+
+const BakedReflectionsGizmo = preload("res://addons/godot-steam-audio/src/steam_audio_baked_reflections_gizmo.gd")
+
+var _button: Button
+var _progress_dialog: AcceptDialog
+var _progress_bar: ProgressBar
+var _cancel_button: Button
+var _status_label: Label
+var _is_processing: bool = false
+var _should_cancel: bool = false
+var _gizmo_plugin: EditorNode3DGizmoPlugin
+
+
+func _enter_tree() -> void:
+	_create_button()
+	_create_progress_dialog()
+	
+	# Register the gizmo plugin
+	_gizmo_plugin = BakedReflectionsGizmo.new()
+	add_node_3d_gizmo_plugin(_gizmo_plugin)
+
+	# Connect to selection changes
+	var selection := EditorInterface.get_selection()
+	selection.selection_changed.connect(_on_selection_changed)
+
+	# Initial visibility check
+	_update_button_visibility()
+
+
+func _exit_tree() -> void:
+	var selection := EditorInterface.get_selection()
+	if selection.selection_changed.is_connected(_on_selection_changed):
+		selection.selection_changed.disconnect(_on_selection_changed)
+	
+	# Unregister the gizmo plugin
+	if _gizmo_plugin:
+		remove_node_3d_gizmo_plugin(_gizmo_plugin)
+		_gizmo_plugin = null
+
+	if _button:
+		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, _button)
+		_button.queue_free()
+	if _progress_dialog:
+		_progress_dialog.queue_free()
+
+
+func _create_button() -> void:
+	_button = Button.new()
+	_button.text = "Bake Reflections"
+	_button.pressed.connect(_on_bake_button_pressed)
+	_button.visible = false  # Hidden by default until correct node selected
+	add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, _button)
+
+
+func _create_progress_dialog() -> void:
+	_progress_dialog = AcceptDialog.new()
+	_progress_dialog.title = "Baking Reflections"
+	_progress_dialog.size = Vector2i(400, 150)
+	_progress_dialog.exclusive = true
+	_progress_dialog.unresizable = true
+	# Hide the default OK button
+	_progress_dialog.get_ok_button().hide()
+	# Prevent closing via X button while processing
+	_progress_dialog.close_requested.connect(_on_dialog_close_requested)
+
+	var vbox := VBoxContainer.new()
+	vbox.set_anchors_preset(Control.PRESET_FULL_RECT)
+	vbox.set_offsets_preset(Control.PRESET_FULL_RECT, Control.PRESET_MODE_MINSIZE, 8)
+	_progress_dialog.add_child(vbox)
+
+	_status_label = Label.new()
+	_status_label.text = "Initializing..."
+	_status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(_status_label)
+
+	_progress_bar = ProgressBar.new()
+	_progress_bar.min_value = 0.0
+	_progress_bar.max_value = 100.0
+	_progress_bar.value = 0.0
+	_progress_bar.show_percentage = true
+	_progress_bar.custom_minimum_size = Vector2(380, 30)
+	vbox.add_child(_progress_bar)
+
+	var spacer := Control.new()
+	spacer.custom_minimum_size = Vector2(0, 10)
+	vbox.add_child(spacer)
+
+	var button_container := HBoxContainer.new()
+	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.add_child(button_container)
+
+	_cancel_button = Button.new()
+	_cancel_button.text = "Cancel"
+	_cancel_button.custom_minimum_size = Vector2(100, 30)
+	_cancel_button.pressed.connect(_on_cancel_pressed)
+	button_container.add_child(_cancel_button)
+
+	EditorInterface.get_base_control().add_child(_progress_dialog)
+
+
+func _on_selection_changed() -> void:
+	_update_button_visibility()
+
+
+func _update_button_visibility() -> void:
+	if not _button:
+		return
+
+	_button.visible = _get_selected_baked_reflections_node() != null
+
+
+func _get_selected_baked_reflections_node() -> Node:
+	var selection := EditorInterface.get_selection()
+	var selected_nodes := selection.get_selected_nodes()
+
+	for node in selected_nodes:
+		# Check by class name string (works even if class isn't directly available)
+		if node.get_class() == "SteamAudioBakedReflections":
+			return node
+
+	return null
+
+
+func _on_bake_button_pressed() -> void:
+	if _is_processing:
+		return
+
+	var target_node := _get_selected_baked_reflections_node()
+	if not target_node:
+		return
+
+	_is_processing = true
+	_should_cancel = false
+	_progress_bar.value = 0.0
+	_status_label.text = "Starting bake process..."
+	_cancel_button.text = "Cancel"
+	_cancel_button.disabled = false
+
+	_progress_dialog.popup_centered()
+
+	# Start the bake process with the selected node
+	_do_bake_process(target_node)
+
+
+func _do_bake_process(target_node: Node) -> void:
+	target_node.start_bake()
+
+	while target_node.get_is_baking():
+		if _should_cancel:
+			# TODO: Add cancel method if available on baker
+			_status_label.text = "Cancelled!"
+			_progress_bar.value = 0.0
+			_is_processing = false
+			_cancel_button.text = "Close"
+			_cancel_button.disabled = false
+			return
+
+		var progress := int(target_node.get_bake_progress() * 100.0)
+		_progress_bar.value = progress
+		_status_label.text = "Baking reflections: %.1f%%" % progress
+
+		# Yield to allow UI updates
+		await get_tree().process_frame
+
+	# Completed
+	_progress_bar.value = 100.0
+	_status_label.text = "Bake complete!"
+	_is_processing = false
+	_cancel_button.text = "Close"
+
+
+func _on_cancel_pressed() -> void:
+	if _is_processing:
+		_should_cancel = true
+		_cancel_button.disabled = true
+		_status_label.text = "Cancelling..."
+	else:
+		_progress_dialog.hide()
+
+
+func _on_dialog_close_requested() -> void:
+	if not _is_processing:
+		_progress_dialog.hide()
+	# If processing, ignore the close request (modal stays open)

--- a/src/baked_reflection_data.cpp
+++ b/src/baked_reflection_data.cpp
@@ -1,0 +1,74 @@
+#include "baked_reflection_data.hpp"
+#include "server.hpp"
+
+#include <cstring>
+#include <godot_cpp/classes/resource_saver.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+void SteamAudioBakedReflectionData::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_serialized_data", "data"), &SteamAudioBakedReflectionData::set_serialized_data);
+	ClassDB::bind_method(D_METHOD("get_serialized_data"), &SteamAudioBakedReflectionData::get_serialized_data);
+
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "serialized_data"), "set_serialized_data", "get_serialized_data");
+}
+
+SteamAudioBakedReflectionData::SteamAudioBakedReflectionData() {
+}
+
+SteamAudioBakedReflectionData::~SteamAudioBakedReflectionData() {
+}
+
+void SteamAudioBakedReflectionData::set_data(IPLSerializedObject serialized_object) {
+	auto data = static_cast<const IPLbyte *>(iplSerializedObjectGetData(serialized_object));
+	const IPLsize size = iplSerializedObjectGetSize(serialized_object);
+	serialized_data.resize(size);
+	if (size > 0 && data != nullptr) {
+		uint8_t *dst = serialized_data.ptrw();
+		// Copy byte-for-byte from Steam Audio serialized object into our PackedByteArray
+		std::memcpy(dst, data, static_cast<size_t>(size));
+	}
+
+	Error result = ResourceSaver::get_singleton()->save(this, get_path(), ResourceSaver::FLAG_COMPRESS);
+	if (result != OK) {
+		UtilityFunctions::push_error("Failed to save the baked reflection data resource. Error code: " + String::num_int64(result));
+	}
+}
+
+IPLSerializedObject SteamAudioBakedReflectionData::get_data() {
+	// If no bytes are stored, return null to signal absence of baked data.
+	if (serialized_data.is_empty()) {
+		UtilityFunctions::push_warning("[Steam Audio] Baked reflections resource has no data (0 bytes).");
+		return nullptr;
+	}
+	// Guard against use before SteamAudioServer global state is initialized.
+	SteamAudioServer *srv = SteamAudioServer::get_singleton();
+	if (!srv) {
+		UtilityFunctions::push_error("[Steam Audio] SteamAudioServer singleton is null when requesting baked data.");
+		return nullptr;
+	}
+	GlobalSteamAudioState *gs = srv->get_global_state(false);
+	if (!gs || !gs->ctx) {
+		UtilityFunctions::push_warning("[Steam Audio] Global state/context not initialized; returning null serialized object for baked reflections.");
+		return nullptr;
+	}
+
+	IPLSerializedObject serialized_object{};
+	IPLSerializedObjectSettings settings = { serialized_data.ptrw(), static_cast<IPLsize>(serialized_data.size()) };
+	IPLerror err = iplSerializedObjectCreate(gs->ctx, &settings, &serialized_object);
+	if (err != IPL_STATUS_SUCCESS) {
+		UtilityFunctions::push_error("[Steam Audio] Failed to create serialized object from baked reflection resource. Status: " + String::num_int64(err));
+		return nullptr;
+	}
+	return serialized_object;
+}
+
+void SteamAudioBakedReflectionData::set_serialized_data(const PackedByteArray &p_data) {
+	serialized_data = p_data;
+}
+
+PackedByteArray SteamAudioBakedReflectionData::get_serialized_data() const {
+	return serialized_data;
+}

--- a/src/baked_reflection_data.hpp
+++ b/src/baked_reflection_data.hpp
@@ -1,0 +1,30 @@
+#ifndef GODOT_STEAM_AUDIO_REFLECTION_BAKED_DATA_HPP
+#define GODOT_STEAM_AUDIO_REFLECTION_BAKED_DATA_HPP
+
+#include <phonon.h>
+#include <godot_cpp/classes/resource.hpp>
+
+namespace godot {
+
+class SteamAudioBakedReflectionData : public Resource {
+	GDCLASS(SteamAudioBakedReflectionData, Resource)
+
+private:
+	PackedByteArray serialized_data;
+
+protected:
+	static void _bind_methods();
+
+public:
+	SteamAudioBakedReflectionData();
+	~SteamAudioBakedReflectionData();
+
+	void set_data(IPLSerializedObject data);
+	IPLSerializedObject get_data();
+	void set_serialized_data(const PackedByteArray &p_data);
+	PackedByteArray get_serialized_data() const;
+};
+
+} //namespace godot
+
+#endif // GODOT_STEAM_AUDIO_BAKED_REFLECTION_BAKED_DATA_HPP

--- a/src/baked_reflections.cpp
+++ b/src/baked_reflections.cpp
@@ -1,0 +1,727 @@
+#include "baked_reflections.hpp"
+#include "server.hpp"
+
+#include <functional>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/node3d.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/window.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "geometry.hpp"
+
+#include "player.hpp"
+#include "steam_audio.hpp"
+
+using namespace godot;
+
+// Note: Matrix helpers centralized in steam_audio.hpp (ipl_matrix_row_major_from /
+// ipl_matrix_transposed_from) to avoid duplication and confusion about layout.
+
+void SteamAudioBakedReflections::_ready() {
+	SteamAudioServer::get_singleton()->set_baked_reflections(this);
+}
+
+void SteamAudioBakedReflections::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_EXIT_TREE:
+			// Clear baked reflections when this node is removed from the scene tree
+			if (SteamAudioServer::get_singleton()) {
+				SteamAudioServer::get_singleton()->clear_baked_reflections(this);
+			}
+			break;
+	}
+}
+
+void SteamAudioBakedReflections::_bind_methods() {
+	// Bind methods
+	ClassDB::bind_method(D_METHOD("set_baked_data", "data"), &SteamAudioBakedReflections::set_baked_data);
+	ClassDB::bind_method(D_METHOD("get_baked_data"), &SteamAudioBakedReflections::get_baked_data);
+	ClassDB::bind_method(D_METHOD("start_bake"), &SteamAudioBakedReflections::start_bake);
+	ClassDB::bind_method(D_METHOD("clear"), &SteamAudioBakedReflections::clear);
+	ClassDB::bind_method(D_METHOD("get_is_baking"), &SteamAudioBakedReflections::get_is_baking);
+	ClassDB::bind_method(D_METHOD("get_bake_progress"), &SteamAudioBakedReflections::get_bake_progress);
+	// finalize_bake is called via call_deferred from a background thread; bind it so Godot can resolve the method.
+	ClassDB::bind_method(D_METHOD("finalize_bake"), &SteamAudioBakedReflections::finalize_bake);
+	// Editor gizmo helper: return last generated probe positions (local space).
+	ClassDB::bind_method(D_METHOD("get_probe_positions"), &SteamAudioBakedReflections::get_probe_positions);
+	ClassDB::bind_method(D_METHOD("set_num_rays", "num_rays"), &SteamAudioBakedReflections::set_num_rays);
+	ClassDB::bind_method(D_METHOD("get_num_rays"), &SteamAudioBakedReflections::get_num_rays);
+	ClassDB::bind_method(D_METHOD("set_num_bounces", "num_bounces"), &SteamAudioBakedReflections::set_num_bounces);
+	ClassDB::bind_method(D_METHOD("get_num_bounces"), &SteamAudioBakedReflections::get_num_bounces);
+	ClassDB::bind_method(D_METHOD("set_duration", "duration"), &SteamAudioBakedReflections::set_duration);
+	ClassDB::bind_method(D_METHOD("get_duration"), &SteamAudioBakedReflections::get_duration);
+	ClassDB::bind_method(D_METHOD("set_num_diffuse_samples", "num_diffuse_samples"), &SteamAudioBakedReflections::set_num_diffuse_samples);
+	ClassDB::bind_method(D_METHOD("get_num_diffuse_samples"), &SteamAudioBakedReflections::get_num_diffuse_samples);
+	ClassDB::bind_method(D_METHOD("set_irradiance_min_distance", "irradiance_min_distance"), &SteamAudioBakedReflections::set_irradiance_min_distance);
+	ClassDB::bind_method(D_METHOD("get_irradiance_min_distance"), &SteamAudioBakedReflections::get_irradiance_min_distance);
+	ClassDB::bind_method(D_METHOD("set_bake_parametric", "bake_parametric"), &SteamAudioBakedReflections::set_bake_parametric);
+	ClassDB::bind_method(D_METHOD("get_bake_parametric"), &SteamAudioBakedReflections::get_bake_parametric);
+	ClassDB::bind_method(D_METHOD("set_bake_convolution", "bake_convolution"), &SteamAudioBakedReflections::set_bake_convolution);
+	ClassDB::bind_method(D_METHOD("get_bake_convolution"), &SteamAudioBakedReflections::get_bake_convolution);
+	// center/radius bindings removed
+	ClassDB::bind_method(D_METHOD("set_probe_spacing", "probe_spacing"), &SteamAudioBakedReflections::set_probe_spacing);
+	ClassDB::bind_method(D_METHOD("get_probe_spacing"), &SteamAudioBakedReflections::get_probe_spacing);
+	ClassDB::bind_method(D_METHOD("set_probe_height", "probe_height"), &SteamAudioBakedReflections::set_probe_height);
+	ClassDB::bind_method(D_METHOD("get_probe_height"), &SteamAudioBakedReflections::get_probe_height);
+	ClassDB::bind_method(D_METHOD("set_probe_generation_extents", "probe_generation_extents"), &SteamAudioBakedReflections::set_probe_generation_extents);
+	ClassDB::bind_method(D_METHOD("get_probe_generation_extents"), &SteamAudioBakedReflections::get_probe_generation_extents);
+
+	ClassDB::bind_method(D_METHOD("set_include_scene_probes", "include_scene_probes"), &SteamAudioBakedReflections::set_include_scene_probes);
+	ClassDB::bind_method(D_METHOD("get_include_scene_probes"), &SteamAudioBakedReflections::get_include_scene_probes);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_scene_probes"), "set_include_scene_probes", "get_include_scene_probes");
+
+	// Add properties
+	ADD_GROUP("Reflection Bake", "");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "num_rays"), "set_num_rays", "get_num_rays");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "num_bounces"), "set_num_bounces", "get_num_bounces");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "duration"), "set_duration", "get_duration");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "num_diffuse_samples"), "set_num_diffuse_samples", "get_num_diffuse_samples");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "irradiance_min_distance"), "set_irradiance_min_distance", "get_irradiance_min_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_parametric"), "set_bake_parametric", "get_bake_parametric");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_convolution"), "set_bake_convolution", "get_bake_convolution");
+
+	ADD_GROUP("Scene", "");
+	/* center and radius removed: probe generation uses node transform + extents */
+
+	ADD_GROUP("Probes", "");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "probe_spacing"), "set_probe_spacing", "get_probe_spacing");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "probe_height"), "set_probe_height", "get_probe_height");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "probe_generation_extents"), "set_probe_generation_extents", "get_probe_generation_extents");
+
+	ADD_GROUP("Bake Data", "");
+	// Expose the baked data resource so GDScript can assign/read it.
+	// Use the actual registered class name for the resource type hint.
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "baked_data", PROPERTY_HINT_RESOURCE_TYPE, "SteamAudioBakedReflectionData"), "set_baked_data", "get_baked_data");
+
+	// Options for STATICSOURCE baking
+	ClassDB::bind_method(D_METHOD("set_bake_static_sources", "bake_static_sources"), &SteamAudioBakedReflections::set_bake_static_sources);
+	ClassDB::bind_method(D_METHOD("get_bake_static_sources"), &SteamAudioBakedReflections::get_bake_static_sources);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_static_sources"), "set_bake_static_sources", "get_bake_static_sources");
+
+	ClassDB::bind_method(D_METHOD("set_static_source_radius", "radius"), &SteamAudioBakedReflections::set_static_source_radius);
+	ClassDB::bind_method(D_METHOD("get_static_source_radius"), &SteamAudioBakedReflections::get_static_source_radius);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "static_source_radius", PROPERTY_HINT_RANGE, "0,10000,1"), "set_static_source_radius", "get_static_source_radius");
+}
+
+SteamAudioBakedReflections::SteamAudioBakedReflections() {
+	probe_batch = nullptr;
+	is_baking = false;
+	bake_progress = 0.0f;
+
+	// Initialize properties from ReflectionBakeConfig
+	num_rays = 32768;
+	num_bounces = 64;
+	duration = 2.0f;
+	num_diffuse_samples = 1024;
+	irradiance_min_distance = 1.0f;
+	bake_parametric = true;
+	bake_convolution = true;
+	bake_static_sources = true; // default on for parity with Unity/UE workflows
+	static_source_radius = 1000.0f; // match listener default
+
+	// Sensible defaults for scene influence and probe generation to avoid empty bakes.
+	// scene center/radius removed — use node transform and `probe_generation_extents` instead
+
+	probe_spacing = 4.0f;
+	probe_height = 1.5f;
+	// Default extents (X,Z size and Y thickness) for uniform floor generation.
+	probe_generation_extents = Vector3(20.0f, 1.0f, 20.0f);
+	include_scene_probes = true; // sensible default: include manual probes
+}
+
+SteamAudioBakedReflections::~SteamAudioBakedReflections() {
+	SteamAudio::log(SteamAudio::log_info, "SteamAudioBakedReflections destructor called for " + String::num_int64(reinterpret_cast<int64_t>(this)));
+
+	// Notify server to clear the reference before destruction
+	if (SteamAudioServer::get_singleton()) {
+		SteamAudio::log(SteamAudio::log_info, "Notifying server to clear baked reflections...");
+		SteamAudioServer::get_singleton()->clear_baked_reflections(this);
+	} else {
+		SteamAudio::log(SteamAudio::log_warn, "Server singleton is null, cannot clear baked reflections!");
+	}
+
+	// Ensure background bake thread is joined before destruction.
+	if (bake_thread.joinable()) {
+		bake_thread.join();
+	}
+	if (probe_batch) {
+		iplProbeBatchRelease(&probe_batch);
+	}
+
+	SteamAudio::log(SteamAudio::log_info, "SteamAudioBakedReflections destructor completed.");
+}
+
+void SteamAudioBakedReflections::generate_probes() {
+	// Recreate probe batch if it already exists.
+	if (probe_batch) {
+		iplProbeBatchRelease(&probe_batch);
+		probe_batch = nullptr;
+	}
+	// Build transform from this node's global transform (Node3D).
+	Transform3D xf = get_global_transform();
+	// Apply user-configured probe_generation_extents as a scale on the local unit cube volume,
+	// mirroring Unity's behavior where the GameObject's scale defines the generation volume.
+	// This keeps existing extents property functional even if the node's scale is left at 1.
+	xf.basis.scale(probe_generation_extents);
+	// Build the transform matrix for Steam Audio's probe generation.
+	// IPLMatrix4x4 uses column-major convention (basis vectors as columns) despite row-major
+	// memory layout. Unity applies Z-flip transforms and copies directly; Unreal transposes
+	// from its row-major FMatrix. Godot stores basis transposed internally, so we use the
+	// corrected conversion that properly handles this.
+	IPLMatrix4x4 xf_matrix = ipl_matrix_from(xf);
+
+	IPLProbeGenerationParams probe_params{};
+	probe_params.type = IPL_PROBEGENERATIONTYPE_UNIFORMFLOOR; // default strategy; can be exposed later
+	probe_params.spacing = probe_spacing;
+	probe_params.height = probe_height;
+	probe_params.transform = xf_matrix;
+
+	// Debug dump of transform and probe params to help diagnose 0-probe cases.
+	{
+		Vector3 pos = xf.origin;
+		Vector3 c0 = xf.basis.get_column(0);
+		Vector3 c1 = xf.basis.get_column(1);
+		Vector3 c2 = xf.basis.get_column(2);
+		SteamAudio::log(SteamAudio::log_debug, "Probe gen transform pos: " + String(pos));
+		SteamAudio::log(SteamAudio::log_debug, "Basis columns X: " + String(c0) + " Y: " + String(c1) + " Z: " + String(c2));
+		SteamAudio::log(SteamAudio::log_debug, "Probe params type=UNIFORMFLOOR spacing=" + String::num_real(probe_spacing) + " height=" + String::num_real(probe_height));
+		// Print matrix rows (column-major transform in row-major storage)
+		SteamAudio::log(SteamAudio::log_debug, "IPLMatrix4x4 (column-major transform):");
+		for (int r = 0; r < 4; ++r) {
+			SteamAudio::log(SteamAudio::log_debug, "  [" + String::num_real(xf_matrix.elements[r][0]) + ", " + String::num_real(xf_matrix.elements[r][1]) + ", " + String::num_real(xf_matrix.elements[r][2]) + ", " + String::num_real(xf_matrix.elements[r][3]) + "]");
+		}
+	}
+
+	// Ensure global state is initialized before accessing context/scene.
+	GlobalSteamAudioState *gs = SteamAudioServer::get_singleton()->get_global_state(true);
+	if (!gs) {
+		UtilityFunctions::push_error("[Steam Audio] Global state is not initialized; cannot generate probes.");
+		return;
+	}
+	IPLContext context = gs->ctx;
+	IPLScene scene = gs->scene;
+
+	// If we're in the editor (most baking is initiated there), ensure the Steam Audio scene actually
+	// has geometry by forcing all SteamAudioGeometry nodes to (re)create and register their meshes.
+	// At runtime, SteamAudioGeometry registers itself, but in the editor it early-outs; this ensures
+	// geometry is present for probe generation without requiring a separate export step.
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		int forced_geo = 0;
+		SceneTree *tree = get_tree();
+		if (tree && tree->get_root()) {
+			// Recursive traversal to find SteamAudioGeometry nodes.
+			std::function<void(Node *)> visit = [&](Node *n) {
+				if (!n)
+					return;
+				if (auto *geo = Object::cast_to<SteamAudioGeometry>(n)) {
+					geo->recalculate(); // creates + registers geometry into the Steam Audio scene
+					++forced_geo;
+				}
+				const int child_count = n->get_child_count();
+				for (int i = 0; i < child_count; ++i) {
+					visit(n->get_child(i));
+				}
+			};
+			visit(tree->get_root());
+		}
+		SteamAudio::log(SteamAudio::log_debug, "Forced (re)registration of SteamAudioGeometry nodes: " + String::num_int64(forced_geo));
+	}
+	// Ensure the scene is committed before generating probes, matching Unity flow.
+	if (scene) {
+		iplSceneCommit(scene);
+	}
+
+	// Dump scene geometry state for debugging
+	SteamAudioServer::get_singleton()->debug_dump_scene_geometry();
+
+	IPLProbeArray probe_array = nullptr;
+	iplProbeArrayCreate(context, &probe_array);
+	iplProbeArrayGenerateProbes(probe_array, scene, &probe_params);
+	// Log probe array count before committing to batch
+	int arr_count = 0;
+	if (probe_array) {
+		arr_count = iplProbeArrayGetNumProbes(probe_array);
+	}
+	SteamAudio::log(SteamAudio::log_debug, "ProbeArray count: " + String::num_int64(arr_count));
+
+	// Fallback: if UniformFloor yields 0 probes, try Centroid generation in same volume.
+	// Note: This SDK does not expose IPL_PROBEGENERATIONTYPE_UNIFORM; available types are
+	// CENTROID and UNIFORMFLOOR. We therefore fall back to CENTROID when floor placement fails.
+	if (arr_count == 0 && probe_params.type == IPL_PROBEGENERATIONTYPE_UNIFORMFLOOR) {
+		// Match expected diagnostic phrasing exactly for easier troubleshooting.
+		UtilityFunctions::push_warning("Uniformfloor generated 0 probes: retrying with Centroid strategy");
+		iplProbeArrayRelease(&probe_array);
+		probe_array = nullptr;
+		iplProbeArrayCreate(context, &probe_array);
+		IPLProbeGenerationParams fallback_params = probe_params;
+		fallback_params.type = IPL_PROBEGENERATIONTYPE_CENTROID;
+		iplProbeArrayGenerateProbes(probe_array, scene, &fallback_params);
+		if (probe_array) {
+			arr_count = iplProbeArrayGetNumProbes(probe_array);
+		} else {
+			arr_count = 0;
+		}
+		SteamAudio::log(SteamAudio::log_debug, "ProbeArray count after Centroid fallback: " + String::num_int64(arr_count));
+		// If fallback still yields 0, abort early with a clear message and avoid creating an empty batch
+		// unless the user has manually placed scene probes and opted to include them.
+		if (arr_count == 0 && !include_scene_probes) {
+			UtilityFunctions::push_warning("[Steam Audio] Centroid generated 0 probes as well; aborting probe generation.");
+			last_probe_positions_local.clear();
+			last_probe_count = 0;
+			if (probe_array) {
+				iplProbeArrayRelease(&probe_array);
+				probe_array = nullptr;
+			}
+			return;
+		}
+		if (arr_count == 0 && include_scene_probes) {
+			SteamAudio::log(SteamAudio::log_info, "No generated probes found but manual scene probes are enabled; continuing to include manual probes.");
+		}
+	}
+
+	// Cache probe positions in local space for gizmo before moving into batch
+	last_probe_positions_local.clear();
+	if (probe_array && arr_count > 0) {
+		// Convert from world to local using inverse global transform
+		Transform3D inv = get_global_transform().affine_inverse();
+		last_probe_positions_local.reserve(arr_count);
+		for (int i = 0; i < arr_count; ++i) {
+			IPLSphere s = iplProbeArrayGetProbe(probe_array, i);
+			Vector3 world_pos(s.center.x, s.center.y, s.center.z);
+			Vector3 local_pos = inv.xform(world_pos);
+			last_probe_positions_local.push_back(local_pos);
+		}
+	}
+
+	iplProbeBatchCreate(context, &probe_batch);
+	if (probe_array) {
+		iplProbeBatchAddProbeArray(probe_batch, probe_array);
+	}
+
+	// If configured, include manually placed SteamAudioProbe nodes as explicit probes
+	if (include_scene_probes) {
+		SceneTree *tree = get_tree();
+		Window *root_window = tree ? tree->get_root() : nullptr;
+		Node *root = root_window ? Object::cast_to<Node>(root_window) : nullptr;
+		int manual_found = 0;
+		if (root) {
+			std::function<void(Node *)> visit = [&](Node *n) {
+				if (!n)
+					return;
+				if (auto *sap = Object::cast_to<SteamAudioProbe>(n)) {
+					// Convert probe global position to IPLSphere and add
+					Vector3 p = sap->get_global_position();
+					IPLSphere sph{};
+					sph.center = IPLVector3{ p.x, p.y, p.z };
+					sph.radius = sap->get_radius();
+					iplProbeBatchAddProbe(probe_batch, sph);
+					// Also cache local position for gizmo
+					Transform3D inv = get_global_transform().affine_inverse();
+					Vector3 local_pos = inv.xform(p);
+					last_probe_positions_local.push_back(local_pos);
+					++manual_found;
+					SteamAudio::log(SteamAudio::log_debug, "Manual probe found at: " + String(p) + " radius=" + String::num_real(sap->get_radius()));
+				}
+				const int cc = n->get_child_count();
+				for (int i = 0; i < cc; ++i)
+					visit(n->get_child(i));
+			};
+			visit(root);
+			SteamAudio::log(SteamAudio::log_debug, "Manual probes collected: " + String::num_int64(manual_found));
+		}
+	}
+
+	iplProbeBatchCommit(probe_batch);
+
+	// Debug: report number of probes generated to help diagnose empty/degenerate bakes.
+	int num_probes = iplProbeBatchGetNumProbes(probe_batch);
+	last_probe_count = num_probes;
+	SteamAudio::log(SteamAudio::log_info, "Generated probes: " + String::num_int64(num_probes));
+	if (num_probes <= 1) {
+		UtilityFunctions::push_warning("[Steam Audio] Probe generation produced insufficient probes (" + String::num_int64(num_probes) + "). Aborting bake.\n"
+																																		 "Tips: (1) Increase probe_generation_extents or decrease probe_spacing, (2) ensure geometry is registered and the Steam Audio scene is committed, (3) place the baker over walkable areas.");
+		// Prevent downstream bake from starting by clearing the batch and cached gizmo data.
+		last_probe_positions_local.clear();
+		last_probe_count = 0;
+		iplProbeBatchRelease(&probe_batch);
+		probe_batch = nullptr;
+	}
+
+	// Release temporary probe array
+	if (probe_array) {
+		iplProbeArrayRelease(&probe_array);
+	}
+
+	// Notify editor to update gizmo visualization
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		update_gizmos();
+	}
+}
+
+PackedVector3Array SteamAudioBakedReflections::get_probe_positions() {
+	PackedVector3Array arr;
+	if (last_probe_positions_local.empty()) {
+		return arr;
+	}
+	arr.resize(static_cast<int>(last_probe_positions_local.size()));
+	for (int i = 0; i < (int)last_probe_positions_local.size(); ++i) {
+		arr.set(i, last_probe_positions_local[i]);
+	}
+	return arr;
+}
+
+void SteamAudioBakedReflections::set_baked_data(const Ref<SteamAudioBakedReflectionData> &p_data) {
+	baked_data = p_data;
+}
+
+Ref<SteamAudioBakedReflectionData> SteamAudioBakedReflections::get_baked_data() const {
+	return baked_data;
+}
+
+IPLReflectionsBakeParams SteamAudioBakedReflections::get_bake_params() const {
+	IPLBakedDataIdentifier identifier{};
+	identifier.type = IPL_BAKEDDATATYPE_REFLECTIONS;
+	// Use REVERB as the default baked reflections variation. This matches common usage
+	// and is robust for runtime lookup by the simulator. Other variations can be exposed later.
+	identifier.variation = IPL_BAKEDDATAVARIATION_REVERB;
+	// For REVERB, endpointInfluence is not used.
+	identifier.endpointInfluence.center = IPLVector3{ 0, 0, 0 };
+	identifier.endpointInfluence.radius = 0.0f;
+
+	IPLReflectionsBakeParams params{};
+	// Ensure global scene is available.
+	GlobalSteamAudioState *gs = SteamAudioServer::get_singleton()->get_global_state(true);
+	if (!gs) {
+		UtilityFunctions::push_error("[Steam Audio] Global state is not initialized; cannot build bake params.");
+		return IPLReflectionsBakeParams{};
+	}
+	params.scene = gs->scene;
+	params.probeBatch = probe_batch; // provide probes to bake into
+
+	params.sceneType = IPL_SCENETYPE_DEFAULT;
+	params.identifier = identifier;
+	params.savedDuration = duration;
+	// Also set simulatedDuration; some SDK versions require this to generate data.
+	params.simulatedDuration = duration;
+	params.order = 2;
+	params.numThreads = 8;
+
+	params.numRays = num_rays;
+	params.numBounces = num_bounces;
+	params.numDiffuseSamples = num_diffuse_samples;
+	params.irradianceMinDistance = irradiance_min_distance;
+	if (bake_parametric) {
+		params.bakeFlags = static_cast<IPLReflectionsBakeFlags>(
+				static_cast<int>(params.bakeFlags) | IPL_REFLECTIONSBAKEFLAGS_BAKEPARAMETRIC);
+	}
+	if (bake_convolution) {
+		params.bakeFlags = static_cast<IPLReflectionsBakeFlags>(
+				static_cast<int>(params.bakeFlags) | IPL_REFLECTIONSBAKEFLAGS_BAKECONVOLUTION);
+	}
+	return params;
+}
+
+void SteamAudioBakedReflections::start_bake() {
+	if (is_baking) {
+		return;
+	}
+
+	is_baking = true;
+	bake_progress = 0.0f;
+
+	// Clear any previously stored baked bytes to avoid mistakenly finalizing
+	// with stale data from an earlier bake (can happen across editor play/stop).
+	{
+		std::lock_guard<std::mutex> lock(baked_bytes_mutex);
+		baked_bytes_buffer.clear();
+	}
+
+	// IMPORTANT: Generate probes on the main thread because this touches the scene tree (find_children).
+	generate_probes();
+
+	// Guard: don't start a bake if no probes were generated or probe_batch is invalid.
+	int probe_count = 0;
+	if (probe_batch) {
+		probe_count = iplProbeBatchGetNumProbes(probe_batch);
+	}
+	if (!probe_batch || probe_count <= 1) {
+		UtilityFunctions::push_warning("[Steam Audio] Aborting reflections bake: no probes found in the generation volume.\n"
+									   "Ensure: (1) your Steam Audio scene/geometry is exported and committed, (2) this node's transform/scale encloses walkable areas, and (3) probe_spacing/height are reasonable.\n"
+									   "Hint: You currently have " +
+				String::num_int64(probe_count) + " probe(s); at least 2 are required.");
+		// Reset baking state to indicate failure without hanging the UI.
+		is_baking = false;
+		bake_progress = 0.0f;
+		return;
+	}
+
+	// Collect static source positions on the main thread if enabled.
+	static_source_positions.clear();
+	if (bake_static_sources) {
+		SceneTree *tree = get_tree();
+		Window *root_window = tree ? tree->get_root() : nullptr;
+		Node *root = root_window ? Object::cast_to<Node>(root_window) : nullptr;
+		int found = 0;
+		if (root) {
+			std::function<void(Node *)> dfs = [&](Node *n) {
+				if (!n)
+					return;
+				if (auto *sap = Object::cast_to<SteamAudioPlayer>(n)) {
+					if (sap->is_baked_static_source()) {
+						Vector3 p = sap->get_global_position();
+						static_source_positions.push_back(IPLVector3{ p.x, p.y, p.z });
+						++found;
+						// Log each collected static source position for diagnostics.
+						SteamAudio::log(SteamAudio::log_debug, "Static source found at " + String(p));
+					}
+				}
+				const int cc = n->get_child_count();
+				for (int i = 0; i < cc; ++i)
+					dfs(n->get_child(i));
+			};
+			dfs(root);
+		}
+		SteamAudio::log(SteamAudio::log_info, "Static sources to bake (STATICSOURCE): " + String::num_int64(found));
+	}
+
+	// Run the bake on a background thread to avoid freezing the main thread.
+	if (bake_thread.joinable()) {
+		bake_thread.join();
+	}
+	bake_thread = std::thread([this]() { this->bake_task(); });
+}
+
+void SteamAudioBakedReflections::bake_progress_callback(float progress, void *user_data) {
+	SteamAudioBakedReflections *manager = static_cast<SteamAudioBakedReflections *>(user_data);
+	manager->bake_progress = progress;
+}
+
+bool SteamAudioBakedReflections::get_is_baking() const { return is_baking.load(); }
+float SteamAudioBakedReflections::get_bake_progress() const { return bake_progress.load(); }
+void SteamAudioBakedReflections::set_num_rays(int p_num_rays) { num_rays = p_num_rays; }
+int SteamAudioBakedReflections::get_num_rays() const { return num_rays; }
+void SteamAudioBakedReflections::set_num_bounces(int p_num_bounces) { num_bounces = p_num_bounces; }
+int SteamAudioBakedReflections::get_num_bounces() const { return num_bounces; }
+void SteamAudioBakedReflections::set_duration(float p_duration) { duration = p_duration; }
+float SteamAudioBakedReflections::get_duration() const { return duration; }
+void SteamAudioBakedReflections::set_num_diffuse_samples(int p_num_diffuse_samples) { num_diffuse_samples = p_num_diffuse_samples; }
+int SteamAudioBakedReflections::get_num_diffuse_samples() const { return num_diffuse_samples; }
+void SteamAudioBakedReflections::set_irradiance_min_distance(float p_irradiance_min_distance) { irradiance_min_distance = p_irradiance_min_distance; }
+float SteamAudioBakedReflections::get_irradiance_min_distance() const { return irradiance_min_distance; }
+void SteamAudioBakedReflections::set_bake_parametric(bool p_bake_parametric) { bake_parametric = p_bake_parametric; }
+bool SteamAudioBakedReflections::get_bake_parametric() const { return bake_parametric; }
+void SteamAudioBakedReflections::set_bake_convolution(bool p_bake_convolution) { bake_convolution = p_bake_convolution; }
+bool SteamAudioBakedReflections::get_bake_convolution() const { return bake_convolution; }
+// center/radius accessors removed
+void SteamAudioBakedReflections::set_probe_spacing(float p_probe_spacing) { probe_spacing = p_probe_spacing; }
+float SteamAudioBakedReflections::get_probe_spacing() const { return probe_spacing; }
+void SteamAudioBakedReflections::set_probe_height(float p_probe_height) { probe_height = p_probe_height; }
+float SteamAudioBakedReflections::get_probe_height() const { return probe_height; }
+void SteamAudioBakedReflections::set_probe_generation_extents(Vector3 p_probe_generation_extents) {
+	probe_generation_extents = p_probe_generation_extents;
+	// Notify editor to update gizmo when extents change
+	if (Engine::get_singleton() && Engine::get_singleton()->is_editor_hint()) {
+		update_gizmos();
+	}
+}
+Vector3 SteamAudioBakedReflections::get_probe_generation_extents() const { return probe_generation_extents; }
+
+void SteamAudioBakedReflections::set_include_scene_probes(bool p_include) { include_scene_probes = p_include; }
+bool SteamAudioBakedReflections::get_include_scene_probes() const { return include_scene_probes; }
+
+PackedStringArray SteamAudioBakedReflections::_get_configuration_warnings() const {
+	PackedStringArray res;
+	return res;
+}
+
+void SteamAudioBakedReflections::bake_task() {
+	// Heavy work: run baker and serialize result. Probes must already be generated on the main thread.
+	if (!probe_batch) {
+		// Probes missing; abort safely and clear progress so UI doesn't display
+		// a stale 100% from a previous bake.
+		bake_progress = 0.0f;
+		is_baking = false;
+		return;
+	}
+	// Diagnostic: log that bake task started and some context info to help
+	// diagnose Windows-only instant-complete issues.
+	SteamAudio::log(SteamAudio::log_debug, "bake_task starting on thread");
+#if defined(_WIN32) || defined(_WIN64)
+	SteamAudio::log(SteamAudio::log_debug, "Platform: Windows");
+#else
+	SteamAudio::log(SteamAudio::log_debug, "Platform: Non-Windows");
+#endif
+	// Ensure global state is initialized and valid.
+	GlobalSteamAudioState *gs = SteamAudioServer::get_singleton()->get_global_state(true);
+	if (!gs) {
+		UtilityFunctions::push_error("[Steam Audio] Global state is not initialized; cannot run bake.");
+		bake_progress = 0.0f;
+		is_baking = false;
+		return;
+	}
+	IPLContext context = gs->ctx;
+	// Bake global REVERB first.
+	IPLReflectionsBakeParams params = get_bake_params();
+	iplReflectionsBakerBake(context, &params, &SteamAudioBakedReflections::bake_progress_callback, this);
+
+	// We'll commit after all passes (REVERB + STATICSOURCE) before querying sizes.
+
+	// Then optionally bake STATICSOURCE per collected static source.
+	IPLReflectionsBakeParams sparams = params; // copy shared settings up-front
+	int static_passes = 0;
+	if (!static_source_positions.empty()) {
+		sparams.identifier.variation = IPL_BAKEDDATAVARIATION_STATICSOURCE;
+		for (const IPLVector3 &pos : static_source_positions) {
+			sparams.identifier.endpointInfluence.center = pos;
+			sparams.identifier.endpointInfluence.radius = static_source_radius;
+			iplReflectionsBakerBake(context, &sparams, &SteamAudioBakedReflections::bake_progress_callback, this);
+
+			// Check this specific layer's size
+			IPLsize pass_size = iplProbeBatchGetDataSize(probe_batch, &sparams.identifier);
+			SteamAudio::log(SteamAudio::log_info, "STATICSOURCE data for source at (" + String::num_real(pos.x) + ", " + String::num_real(pos.y) + ", " + String::num_real(pos.z) + "): " + String::num_int64((int64_t)pass_size) + " bytes");
+
+			++static_passes;
+		}
+		SteamAudio::log(SteamAudio::log_info, "STATICSOURCE bake passes: " + String::num_int64((int64_t)static_passes));
+	} else if (bake_static_sources) {
+		SteamAudio::log(SteamAudio::log_info, "STATICSOURCE bake enabled but no static sources were found in the scene.");
+	}
+
+	// IMPORTANT: Commit the probe batch after writing baked data so size queries reflect the new data.
+	iplProbeBatchCommit(probe_batch);
+
+	// Diagnostic: layer sizes after commit
+	IPLsize reverb_size = iplProbeBatchGetDataSize(probe_batch, &params.identifier);
+	if (reverb_size <= 0) {
+		UtilityFunctions::push_warning("[Steam Audio] REVERB bake produced empty data layer.");
+	}
+
+	// Create a serialized object to save the probe batch into
+	IPLSerializedObjectSettings so_settings{};
+	IPLSerializedObject serialized_object = nullptr;
+	IPLerror so_err = iplSerializedObjectCreate(context, &so_settings, &serialized_object);
+	if (so_err != IPL_STATUS_SUCCESS) {
+		// We are in a background thread; avoid heavy Godot calls. Use push_error sparingly.
+		UtilityFunctions::push_error("[Steam Audio] Failed to create serialized object for baked reflections.");
+		bake_progress = 0.0f;
+		is_baking = false;
+		return;
+	}
+	iplProbeBatchSave(probe_batch, serialized_object);
+	// Copy bytes into a temporary buffer to finalize on the main thread.
+	{
+		std::lock_guard<std::mutex> lock(baked_bytes_mutex);
+		const IPLbyte *data_ptr = reinterpret_cast<const IPLbyte *>(iplSerializedObjectGetData(serialized_object));
+		IPLsize data_size = iplSerializedObjectGetSize(serialized_object);
+		baked_bytes_buffer.resize(static_cast<size_t>(data_size));
+		if (data_ptr && data_size > 0) {
+			std::memcpy(baked_bytes_buffer.data(), data_ptr, static_cast<size_t>(data_size));
+		}
+	}
+	iplSerializedObjectRelease(&serialized_object);
+
+	// Defer finalization on the main thread to interact with Godot resources safely.
+	call_deferred("finalize_bake");
+}
+
+// New getters/setters
+void SteamAudioBakedReflections::set_bake_static_sources(bool p_bake_static_sources) { bake_static_sources = p_bake_static_sources; }
+bool SteamAudioBakedReflections::get_bake_static_sources() const { return bake_static_sources; }
+void SteamAudioBakedReflections::set_static_source_radius(float p_radius) { static_source_radius = p_radius; }
+float SteamAudioBakedReflections::get_static_source_radius() const { return static_source_radius; }
+
+void SteamAudioBakedReflections::finalize_bake() {
+	// Recreate a serialized object from bytes and push into the Resource.
+	std::vector<uint8_t> local_copy;
+	{
+		std::lock_guard<std::mutex> lock(baked_bytes_mutex);
+		local_copy = baked_bytes_buffer;
+	}
+	if (local_copy.empty()) {
+		UtilityFunctions::push_warning("[Steam Audio] Finalize called but no baked bytes were produced; aborting finalize.");
+		bake_progress = 0.0f;
+		is_baking = false;
+		return;
+	}
+	// Ensure global state is initialized for finalization.
+	GlobalSteamAudioState *gs = SteamAudioServer::get_singleton()->get_global_state(true);
+	if (!gs) {
+		UtilityFunctions::push_error("[Steam Audio] Global state is not initialized; cannot finalize bake.");
+		bake_progress = 0.0f;
+		is_baking = false;
+		return;
+	}
+	IPLContext context = gs->ctx;
+	IPLSerializedObject serialized_object = nullptr;
+	IPLSerializedObjectSettings settings{};
+	// IPLSerializedObjectSettings::data expects a non-const IPLbyte*.
+	// local_copy.data() yields a non-const uint8_t* here, so cast accordingly.
+	settings.data = local_copy.empty() ? nullptr : reinterpret_cast<IPLbyte *>(local_copy.data());
+	settings.size = static_cast<IPLsize>(local_copy.size());
+	IPLerror so_err = iplSerializedObjectCreate(context, &settings, &serialized_object);
+	if (so_err != IPL_STATUS_SUCCESS) {
+		UtilityFunctions::push_error("[Steam Audio] Failed to finalize baked reflections serialized object.");
+		bake_progress = 0.0f;
+		is_baking = false;
+		return;
+	}
+	if (!baked_data.is_valid()) {
+		baked_data.instantiate();
+	}
+	baked_data->set_data(serialized_object);
+	iplSerializedObjectRelease(&serialized_object);
+
+	// Inform the user and runtime about the result, and register the baked probe batch with the simulator.
+	{
+		const int64_t bytes = static_cast<int64_t>(local_copy.size());
+		const String res_path = baked_data->get_path();
+		SteamAudio::log(SteamAudio::log_info, "Baked reflections saved " + String::num_int64(bytes) + " bytes to resource: " + res_path);
+	}
+
+	// Ensure the simulator uses the freshly baked data (adds/updates the probe batch in the sim).
+	if (SteamAudioServer::get_singleton()) {
+		SteamAudioServer::get_singleton()->set_baked_reflections(this);
+	}
+
+	bake_progress = 1.0f;
+	is_baking = false;
+}
+
+void SteamAudioBakedReflections::clear() {
+	// If a bake is running, wait for it to finish to avoid races.
+	if (bake_thread.joinable()) {
+		bake_thread.join();
+	}
+
+	// Release any existing probe batch so future bakes regenerate from scratch.
+	if (probe_batch) {
+		iplProbeBatchRelease(&probe_batch);
+		probe_batch = nullptr;
+	}
+
+	// Reset cached state used by the editor gizmo and bake pipeline.
+	last_probe_positions_local.clear();
+	last_probe_count = 0;
+
+	// Clear transient buffers used to shuttle baked bytes between threads.
+	{
+		std::lock_guard<std::mutex> lock(baked_bytes_mutex);
+		baked_bytes_buffer.clear();
+		baked_bytes_buffer.shrink_to_fit();
+	}
+	static_source_positions.clear();
+
+	// Reset flags and progress.
+	is_baking = false;
+	bake_progress = 0.0f;
+
+	SteamAudio::log(SteamAudio::log_info, "Baked reflections state cleared. Next bake will regenerate probes and data.");
+
+	// Ensure simulator is aware that there is no active batch from this baker until we bake again.
+	if (SteamAudioServer::get_singleton()) {
+		SteamAudioServer::get_singleton()->set_baked_reflections(this);
+	}
+}

--- a/src/baked_reflections.hpp
+++ b/src/baked_reflections.hpp
@@ -1,0 +1,140 @@
+#ifndef GODOT_STEAM_AUDIO_REFLECTION_BAKER_HPP
+#define GODOT_STEAM_AUDIO_REFLECTION_BAKER_HPP
+
+#include "baked_reflection_data.hpp"
+#include "probe.hpp"
+
+#include <phonon.h>
+#include <atomic>
+#include <godot_cpp/classes/node3d.hpp>
+#include <godot_cpp/variant/packed_vector3_array.hpp>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace godot;
+
+class SteamAudioBakedReflections : public Node3D {
+	GDCLASS(SteamAudioBakedReflections, Node3D)
+
+private:
+	IPLProbeBatch probe_batch;
+	std::atomic_bool is_baking;
+	std::atomic<float> bake_progress;
+	std::thread bake_thread;
+	std::vector<uint8_t> baked_bytes_buffer;
+	std::mutex baked_bytes_mutex;
+	std::atomic<int> last_probe_count{ 0 };
+	std::atomic<long long> last_baked_layer_size{ 0 };
+	// Cached probe positions in this node's LOCAL space (used by editor gizmo).
+	std::vector<Vector3> last_probe_positions_local;
+
+	// config
+	int num_rays;
+	int num_bounces;
+	float duration;
+	int num_diffuse_samples;
+	float irradiance_min_distance;
+	bool bake_parametric;
+	bool bake_convolution;
+	// When true, also bake per-source STATICSOURCE data for sources marked static.
+	bool bake_static_sources;
+	// Radius used for STATICSOURCE endpoint influence during both baking and playback lookup.
+	// This is the single authoritative value - the server reads this at runtime for baked data queries.
+	float static_source_radius;
+
+	// scene: (center/radius removed; probe generation uses node transform + extents)
+
+	// probes
+	float probe_spacing;
+	float probe_height;
+	Vector3 probe_generation_extents;
+	// When true, include manually placed `SteamAudioProbe` nodes in the scene
+	// as explicit probes in the generated probe batch.
+	bool include_scene_probes;
+
+	// Cached source positions collected on main thread for STATICSOURCE baking.
+	std::vector<IPLVector3> static_source_positions;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void _ready() override;
+	void _notification(int p_what);
+
+	Ref<SteamAudioBakedReflectionData> baked_data;
+
+	SteamAudioBakedReflections();
+	~SteamAudioBakedReflections();
+
+	void generate_probes();
+
+	// Returns probe positions in this node's local space, for gizmo drawing.
+	PackedVector3Array get_probe_positions();
+
+	void set_baked_data(const Ref<SteamAudioBakedReflectionData> &p_data);
+	Ref<SteamAudioBakedReflectionData> get_baked_data() const;
+
+	void start_bake();
+	bool get_is_baking() const;
+	float get_bake_progress() const;
+
+	void set_num_rays(int p_num_rays);
+	int get_num_rays() const;
+
+	void set_num_bounces(int p_num_bounces);
+	int get_num_bounces() const;
+
+	void set_duration(float p_duration);
+	float get_duration() const;
+
+	void set_num_diffuse_samples(int p_num_diffuse_samples);
+	int get_num_diffuse_samples() const;
+
+	void set_irradiance_min_distance(float p_irradiance_min_distance);
+	float get_irradiance_min_distance() const;
+
+	void set_bake_parametric(bool p_bake_parametric);
+	bool get_bake_parametric() const;
+
+	void set_bake_convolution(bool p_bake_convolution);
+	bool get_bake_convolution() const;
+
+	void set_bake_static_sources(bool p_bake_static_sources);
+	bool get_bake_static_sources() const;
+
+	void set_static_source_radius(float p_radius);
+	float get_static_source_radius() const;
+
+	// center/radius removed
+
+	void set_probe_spacing(float p_probe_spacing);
+	float get_probe_spacing() const;
+
+	void set_probe_height(float p_probe_height);
+	float get_probe_height() const;
+
+	void set_probe_generation_extents(Vector3 p_probe_generation_extents);
+	Vector3 get_probe_generation_extents() const;
+
+	void set_include_scene_probes(bool p_include);
+	bool get_include_scene_probes() const;
+
+	IPLReflectionsBakeParams get_bake_params() const;
+
+	PackedStringArray _get_configuration_warnings() const override;
+
+private:
+	static void bake_progress_callback(float progress, void *user_data);
+	void bake_task();
+	void finalize_bake();
+
+public:
+	// Clears any in-memory baking state (probe batch, cached probe gizmo positions,
+	// in-flight bake thread progress buffer). Does NOT modify the baked_data resource.
+	// Use this before re-baking if you suspect stale probe batches or progress state.
+	void clear();
+};
+
+#endif // GODOT_STEAM_AUDIO_REFLECTION_BAKER_HPP

--- a/src/geometry_common.hpp
+++ b/src/geometry_common.hpp
@@ -29,6 +29,10 @@ inline IPLStaticMesh godot_mesh_to_ipl_mesh(Ref<Mesh> mesh, IPLScene scene, IPLM
 	std::vector<IPLTriangle> ipl_tris(tris.size() / 3);
 	std::vector<IPLint32> ipl_mat_indices(tris.size() / 3);
 
+	// Apply the provided Transform3D to move mesh vertices into the world (or
+	// desired) space before handing them to Steam Audio. Steam Audio expects
+	// positions in the simulation space; Godot stores vertices in local mesh
+	// space, so this transform is necessary and not redundant.
 	for (int j = 0; j < verts.size(); j++) {
 		Vector3 vert = verts[j];
 		vert = trf.basis.xform(vert);
@@ -37,7 +41,8 @@ inline IPLStaticMesh godot_mesh_to_ipl_mesh(Ref<Mesh> mesh, IPLScene scene, IPLM
 	}
 
 	for (int j = 0; j < tris.size(); j += 3) {
-		// godot tris are cw, ipl tris are ccw
+		// Godot triangle winding is clockwise; Steam Audio expects counter-clockwise.
+		// Flip to maintain correct face orientation and normals in simulation.
 		ipl_tris[j / 3].indices[0] = tris[j];
 		ipl_tris[j / 3].indices[1] = tris[j + 2];
 		ipl_tris[j / 3].indices[2] = tris[j + 1];

--- a/src/geometry_dynamic.cpp
+++ b/src/geometry_dynamic.cpp
@@ -65,22 +65,19 @@ void SteamAudioDynamicGeometry::process_internal(double delta) {
 		}
 	}
 
-	auto orig = get_global_transform().origin;
-	auto right = get_global_transform().get_basis().get_column(0);
-	auto up = get_global_transform().get_basis().get_column(1);
-	auto fwd = -get_global_transform().get_basis().get_column(2);
-
-	IPLMatrix4x4 new_trf{
-		{
-				{ right.x, right.y, right.z, orig.x },
-				{ up.x, up.y, up.z, orig.y },
-				{ fwd.x, fwd.y, fwd.z, orig.z },
-				{ 0., 0., 0., 1. },
-		}
-	};
+	// Build transform matrix using corrected conversion.
+	// Note: Steam Audio uses standard convention where forward is +Z, but Godot uses -Z.
+	// The matrix conversion handles basis vectors correctly; coordinate flipping (if needed)
+	// should be handled consistently across all matrix uses.
+	IPLMatrix4x4 new_trf = ipl_matrix_from(get_global_transform());
 
 	// TODO: check if it improves perf to skip this if the object does not move.
-	iplInstancedMeshUpdateTransform(mesh, SteamAudioServer::get_singleton()->get_global_state()->scene, new_trf);
+	SteamAudioServer *server = SteamAudioServer::get_singleton();
+	if (server == nullptr) {
+		return;
+	}
+	iplInstancedMeshUpdateTransform(mesh, server->get_global_state()->scene, new_trf);
+	server->notify_scene_dirty();
 }
 
 Ref<SteamAudioMaterial> SteamAudioDynamicGeometry::get_material() { return mat; }

--- a/src/listener.cpp
+++ b/src/listener.cpp
@@ -19,6 +19,11 @@ void SteamAudioListener::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_refl_ambisonics_order"), &SteamAudioListener::get_refl_ambisonics_order);
 	ClassDB::bind_method(D_METHOD("set_refl_ambisonics_order", "p_refl_ambisonics_order"), &SteamAudioListener::set_refl_ambisonics_order);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "reflection_ambisonics_order", PROPERTY_HINT_RANGE, "0,5,1"), "set_refl_ambisonics_order", "get_refl_ambisonics_order");
+
+	// Reflection/Reverb Type selection like Unity/UE (Auto/Realtime/Baked)
+	ClassDB::bind_method(D_METHOD("get_reflection_mode"), &SteamAudioListener::get_reflection_mode);
+	ClassDB::bind_method(D_METHOD("set_reflection_mode", "p_mode"), &SteamAudioListener::set_reflection_mode);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "reflection_type", PROPERTY_HINT_ENUM, "Auto,Realtime,Baked"), "set_reflection_mode", "get_reflection_mode");
 }
 
 void SteamAudioListener::ready_internal() {

--- a/src/listener.hpp
+++ b/src/listener.hpp
@@ -11,11 +11,22 @@ class SteamAudioListener : public Node3D {
 	GDCLASS(SteamAudioListener, Node3D);
 
 private:
+	// Matches Unity/UE-style control where the listener can choose
+	// whether reflections/reverb are simulated in real-time or read from baked data.
+	// AUTO = choose based on availability (default), REALTIME = force real-time,
+	// BAKED = force baked (no fallback to real-time if missing baked data).
+	enum ReflectionMode {
+		REFLECTION_MODE_AUTO = 0,
+		REFLECTION_MODE_REALTIME = 1,
+		REFLECTION_MODE_BAKED = 2,
+	};
+
 	int num_refl_rays = 4096;
 	int num_refl_bounces = 16;
 	float refl_duration = 2.0f;
 	int refl_ambisonics_order = 1;
 	float irradiance_min_dist = 1.0f;
+	int reflection_mode = REFLECTION_MODE_AUTO;
 
 	void ready_internal();
 
@@ -38,6 +49,11 @@ public:
 	void set_refl_duration(float p_refl_duration);
 	float get_irradiance_min_dist();
 	void set_irradiance_min_dist(float p_irradiance_min_dist);
+
+	// Listener-controlled Reflections/Reverb type selection
+	// 0 = Auto, 1 = Realtime, 2 = Baked
+	int get_reflection_mode() const { return reflection_mode; }
+	void set_reflection_mode(int p_mode) { reflection_mode = p_mode; }
 
 	PackedStringArray _get_configuration_warnings() const override;
 };

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -65,6 +65,12 @@ void SteamAudioPlayer::_bind_methods() {
 	ADD_GROUP("Reflection", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reflection"), "set_reflection_on", "is_reflection_on");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_reflection_distance", PROPERTY_HINT_RANGE, "0.0,20000.0,0.1"), "set_max_reflection_distance", "get_max_reflection_distance");
+
+	// Baked Static Source flag (matches Unity's checkbox). When true and a STATICSOURCE
+	// baked layer is present, the server may use STATICSOURCE baked reflections for this source.
+	ClassDB::bind_method(D_METHOD("is_baked_static_source"), &SteamAudioPlayer::is_baked_static_source);
+	ClassDB::bind_method(D_METHOD("set_baked_static_source", "p_baked_static_source"), &SteamAudioPlayer::set_baked_static_source);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "baked_static_source"), "set_baked_static_source", "is_baked_static_source");
 }
 
 SteamAudioPlayer::SteamAudioPlayer() {
@@ -84,10 +90,46 @@ SteamAudioPlayer::SteamAudioPlayer() {
 			new_stream->set_stream(get_stream());
 		}
 		this->set_stream(new_stream);
+	} else {
+		// Ensure the wrapper keeps a valid back-reference after scene reloads.
+		str->parent = this;
 	}
 }
+// Stop playback and release inner/outer stream references.
+void SteamAudioPlayer::release_streams() {
+	// 1) Stop playback on the node FIRST so AudioServer releases its live playback.
+	if (is_playing()) {
+		stop();
+	}
+
+	// 2) Detach the outer stream and clear inner stream to break remaining refs.
+	Ref<AudioStream> outer = get_stream();
+	if (outer.is_valid()) {
+		if (auto *sas = dynamic_cast<SteamAudioStream *>(outer.ptr())) {
+			sas->set_stream(Ref<AudioStream>());
+		}
+		set_stream(Ref<AudioStream>());
+	}
+
+	// 3) Finally clear any cached playback Ref and break back-reference.
+	if (!pb.is_null()) {
+		if (auto *playback = dynamic_cast<SteamAudioStreamPlayback *>(pb.ptr())) {
+			// Ensure the wrapper playback immediately releases its inner
+			// AudioStreamPlayback (e.g., MP3) and inner stream before we drop
+			// our ref, even if AudioServer still holds a reference.
+			playback->_stop();
+			playback->parent = nullptr;
+		}
+		pb = Ref<AudioStreamPlayback>();
+	}
+}
+
 SteamAudioPlayer::~SteamAudioPlayer() {
 	SteamAudio::log(SteamAudio::log_debug, "destroying player");
+	// Always release playback/stream references first to avoid resource leaks on quit.
+	release_streams();
+
+	// If local state was never initialized, we can return after releasing streams.
 	if (!is_local_state_init.load()) {
 		return;
 	}
@@ -96,26 +138,38 @@ SteamAudioPlayer::~SteamAudioPlayer() {
 
 	is_local_state_init.store(false);
 	can_load_local_state.store(false);
-	SteamAudioServer::get_singleton()->remove_local_state(&local_state);
 
-	is_local_state_init.store(false);
-	auto gs = SteamAudioServer::get_singleton()->get_global_state();
+	// Guard server access, as the server singleton may already be destroyed during shutdown.
+	SteamAudioServer *server = SteamAudioServer::get_singleton();
+	GlobalSteamAudioState *gs = nullptr;
+	if (server) {
+		server->remove_local_state(&local_state);
+		gs = server->get_global_state(false);
+	}
 
-	iplSourceRemove(local_state.src.src, gs->sim);
-	iplSourceRelease(&local_state.src.src);
-	iplDirectEffectRelease(&local_state.fx.direct);
+	if (gs && gs->sim && gs->ctx) {
+		iplSourceRemove(local_state.src.src, gs->sim);
+		iplSourceRelease(&local_state.src.src);
+		// Release per-source DSP effects.
+		iplDirectEffectRelease(&local_state.fx.direct);
+		iplReflectionEffectRelease(&local_state.fx.refl);
+		iplReflectionEffectRelease(&local_state.fx.refl_param);
+		iplAmbisonicsDecodeEffectRelease(&local_state.fx.dec);
+		iplAmbisonicsDecodeEffectRelease(&local_state.fx.refl_dec);
+		iplAmbisonicsEncodeEffectRelease(&local_state.fx.enc);
 
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.in);
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.direct);
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.ambi);
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.out);
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.mono);
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.refl_ambi);
-	iplAudioBufferFree(gs->ctx, &local_state.bufs.refl_out);
-
-	if (!pb.is_null()) {
-		auto playback = dynamic_cast<SteamAudioStreamPlayback *>(pb.ptr());
-		playback->parent = nullptr;
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.in);
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.direct);
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.ambi);
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.out);
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.mono);
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.refl_ambi);
+		iplAudioBufferFree(gs->ctx, &local_state.bufs.refl_out);
+	} else {
+		// If global state is already gone, at least null out the pointers we own.
+		local_state.src.src = nullptr;
+		local_state.fx = {};
+		local_state.bufs = {};
 	}
 }
 
@@ -153,6 +207,15 @@ void SteamAudioPlayer::init_local_state() {
 	refl_effect_cfg.numChannels = ambisonic_channels_from(local_state.cfg.ambisonics_order);
 	iplReflectionEffectCreate(gs->ctx, &gs->audio_cfg, &refl_effect_cfg, &local_state.fx.refl);
 
+	// Create a dedicated PARAMETRIC reflection effect instance for baked/parametric reverb
+	IPLReflectionEffectSettings refl_param_cfg{};
+	refl_param_cfg.type = IPL_REFLECTIONEFFECTTYPE_PARAMETRIC;
+	// For PARAMETRIC, Steam Audio expects stereo output.
+	refl_param_cfg.numChannels = 2;
+	// irSize is not used by parametric, but initialize to a sensible frame count.
+	refl_param_cfg.irSize = int(SteamAudioConfig::max_refl_duration * float(gs->audio_cfg.samplingRate));
+	iplReflectionEffectCreate(gs->ctx, &gs->audio_cfg, &refl_param_cfg, &local_state.fx.refl_param);
+
 	local_state.fx.dec = create_ambisonics_decode_effect(
 			gs->ctx, gs->audio_cfg, gs->hrtf);
 	local_state.fx.refl_dec = create_ambisonics_decode_effect(
@@ -183,6 +246,19 @@ void SteamAudioPlayer::_notification(int p_what) {
 		case NOTIFICATION_PROCESS:
 			process_internal(get_process_delta_time());
 			break;
+		case NOTIFICATION_EXIT_TREE:
+			// On regular scene teardown, stop playback but DO NOT clear user-assigned streams.
+			// Clearing streams here causes the inspector's stream reference to be lost across
+			// scene switches. We only fully release streams at pre-delete/destruction.
+			if (is_playing()) {
+				stop();
+			}
+			pb = Ref<AudioStreamPlayback>();
+			break;
+		case NOTIFICATION_PREDELETE:
+			// As a final safeguard, ensure all references are gone before deletion.
+			release_streams();
+			break;
 	}
 }
 
@@ -210,10 +286,20 @@ void SteamAudioPlayer::ready_internal() {
 		}
 		set_stream(new_stream);
 		str = new_stream.ptr();
+	}
+	// Ensure wrapper has correct parent reference even if it already existed.
+	if (str) {
 		str->parent = this;
-		if (is_autoplay_enabled()) {
-			play();
-		}
+	}
+
+	// Force early local-state initialization so DSP path is ready before playback
+	// to avoid missing reflections/reverb on first frames.
+	get_local_state();
+
+	// Robust autoplay: always start playback here if enabled and not already playing,
+	// regardless of whether the stream was newly wrapped or already wrapped.
+	if (is_autoplay_enabled() && !is_playing()) {
+		play();
 	}
 
 	if (cfg.ambisonics_order > SteamAudioConfig::max_ambisonics_order) {
@@ -234,8 +320,13 @@ void SteamAudioPlayer::process_internal(double delta) {
 		set_attenuation_model(ATTENUATION_DISABLED);
 	}
 
-	if (is_playing() && !get_stream_playback().is_null()) {
-		pb = get_stream_playback();
+	if (is_playing()) {
+		if (!get_stream_playback().is_null()) {
+			pb = get_stream_playback();
+		}
+	} else {
+		// If not playing, don't keep a stale cached playback reference.
+		pb = Ref<AudioStreamPlayback>();
 	}
 }
 
@@ -322,6 +413,8 @@ void SteamAudioPlayer::set_air_absorption_model_type(IPLAirAbsorptionModelType p
 
 bool SteamAudioPlayer::is_reflection_on() { return cfg.is_reflection_on; }
 void SteamAudioPlayer::set_reflection_on(bool p_reflection_on) { cfg.is_reflection_on = p_reflection_on; }
+bool SteamAudioPlayer::is_baked_static_source() { return baked_static_source; }
+void SteamAudioPlayer::set_baked_static_source(bool p_baked_static_source) { baked_static_source = p_baked_static_source; }
 bool SteamAudioPlayer::is_occlusion_on() { return cfg.is_occlusion_on; }
 void SteamAudioPlayer::set_occlusion_on(bool p_occlusion_on) { cfg.is_occlusion_on = p_occlusion_on; }
 

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -93,6 +93,9 @@ public:
 	bool is_reflection_on();
 	void set_reflection_on(bool p_reflection_on);
 
+	bool is_baked_static_source();
+	void set_baked_static_source(bool p_baked_static_source);
+
 	bool is_occlusion_on();
 	void set_occlusion_on(bool p_occlusion_on);
 

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -17,6 +17,9 @@ private:
 	// since the player has stopped (even though the playback still mixes...)
 	Ref<AudioStreamPlayback> pb;
 
+	// Stop playback and release inner/outer stream references.
+	void release_streams();
+
 	// TODO: we can probably move these values inside local state
 	// for cleanup and the ability to adjust them at runtime
 	SteamAudioSourceConfig cfg{
@@ -40,6 +43,11 @@ private:
 	LocalSteamAudioState local_state;
 	std::atomic<bool> is_local_state_init;
 	std::atomic<bool> can_load_local_state;
+
+	// When true, this source is treated as a Baked Static Source, allowing
+	// the engine to use STATICSOURCE baked reflections for this source
+	// (matching the Unity plugin's "Baked Static Source" option).
+	bool baked_static_source = false;
 
 	void init_local_state();
 

--- a/src/probe.cpp
+++ b/src/probe.cpp
@@ -1,0 +1,36 @@
+#include <godot_cpp/core/class_db.hpp>
+
+#include "probe.hpp"
+#include "server.hpp"
+
+#include "phonon.h"
+
+using namespace godot;
+
+void SteamAudioProbe::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &SteamAudioProbe::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &SteamAudioProbe::get_radius);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius"), "set_radius", "get_radius");
+}
+
+SteamAudioProbe::SteamAudioProbe() {
+	radius = 1.0f;
+	mesh = memnew(MeshInstance3D);
+	sphere.instantiate();
+	mesh->set_name("mesh");
+	mesh->set_mesh(sphere);
+	sphere->set_radius(radius);
+	add_child(mesh);
+}
+
+SteamAudioProbe::~SteamAudioProbe() {
+}
+
+void SteamAudioProbe::set_radius(float p_radius) {
+	radius = p_radius;
+	sphere->set_radius(radius);
+}
+
+float SteamAudioProbe::get_radius() const {
+	return radius;
+}

--- a/src/probe.hpp
+++ b/src/probe.hpp
@@ -1,0 +1,31 @@
+#ifndef GODOT_STEAM_AUDIO_PROBE_HPP
+#define GODOT_STEAM_AUDIO_PROBE_HPP
+
+#include "godot_cpp/classes/mesh_instance3d.hpp"
+#include "godot_cpp/classes/node3d.hpp"
+#include "godot_cpp/classes/sphere_shape3d.hpp"
+
+#include "phonon.h"
+
+using namespace godot;
+
+class SteamAudioProbe : public Node3D {
+	GDCLASS(SteamAudioProbe, Node3D)
+
+private:
+	MeshInstance3D *mesh;
+	Ref<SphereShape3D> sphere;
+	float radius;
+
+protected:
+	static void _bind_methods();
+
+public:
+	SteamAudioProbe();
+	~SteamAudioProbe();
+
+	void set_radius(float p_radius);
+	float get_radius() const;
+};
+
+#endif // GODOT_STEAM_AUDIO_PROBE_HPP

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,5 +1,7 @@
 #include "register_types.hpp"
 
+#include "baked_reflection_data.hpp"
+#include "baked_reflections.hpp"
 #include "config.hpp"
 #include "geometry.hpp"
 #include "geometry_dynamic.hpp"
@@ -7,6 +9,7 @@
 #include "listener.hpp"
 #include "material.hpp"
 #include "player.hpp"
+#include "probe.hpp"
 #include "server.hpp"
 #include "stream.hpp"
 
@@ -33,6 +36,9 @@ void init_ext(ModuleInitializationLevel p_level) {
 		ClassDB::register_class<SteamAudioMaterial>();
 		ClassDB::register_class<SteamAudioConfig>();
 		ClassDB::register_class<SteamAudioPlayer>();
+		ClassDB::register_class<SteamAudioBakedReflections>();
+		ClassDB::register_class<SteamAudioBakedReflectionData>();
+		ClassDB::register_class<SteamAudioProbe>();
 	}
 
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
@@ -43,9 +49,11 @@ void init_ext(ModuleInitializationLevel p_level) {
 
 void uninit_ext(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
-		// Should call this to not leak, but thread->wait_for_finish() crashes...
-		// the program is exiting anyway so I'm not too concerned
-		// memdelete(srv);
+		// Properly destroy the singleton to avoid leaks (Thread, resources) on app quit.
+		if (srv) {
+			memdelete(srv);
+			srv = nullptr;
+		}
 	}
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -9,42 +9,100 @@
 #include "server_init.hpp"
 #include "steam_audio.hpp"
 #include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/window.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
+#include <thread>
 
 void SteamAudioServer::tick() {
-	if (Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-	if (!self->is_global_state_init.load()) {
-		return;
-	}
-	if (self->listener == nullptr) {
+	// Advance debug frame counter for throttled logging.
+	debug_log_frame_counter++;
+	if (!is_tick_ready()) {
 		return;
 	}
 
 	SteamAudio::log(SteamAudio::log_debug, "tick");
 
-	if (!is_refl_thread_processing.load()) {
-		iplSceneCommit(self->global_state.scene);
+	commit_scene_if_idle();
+
+	global_state.listener_coords =
+			ipl_coords_from(listener->get_global_transform());
+
+	process_direct_simulation();
+
+	if (is_refl_thread_processing.load()) {
+		SteamAudio::log(SteamAudio::log_debug, "tick: done, skipping reflections");
+		return;
 	}
 
+	fetch_reflection_outputs();
+	prepare_reflection_inputs();
+	prepare_reverb_inputs();
+	configure_reflection_shared_inputs();
+	wake_reflection_worker();
+
+	SteamAudio::log(SteamAudio::log_debug, "tick: done");
+}
+
+bool SteamAudioServer::is_tick_ready() const {
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return false;
+	}
+	if (!is_global_state_init.load()) {
+		return false;
+	}
+	if (listener == nullptr) {
+		return false;
+	}
+	return true;
+}
+
+bool SteamAudioServer::is_state_active(LocalSteamAudioState *ls) const {
+	if (ls == nullptr) {
+		return false;
+	}
+	if (ls->src.player == nullptr) {
+		UtilityFunctions::push_warning(
+				"local state has empty player, not updating simulation state");
+		return false;
+	}
+	if (!ls->src.player->is_playing()) {
+		return false;
+	}
+	return true;
+}
+
+bool SteamAudioServer::is_within_refl_range(LocalSteamAudioState *ls) const {
+	return ls->src.player->get_global_position().distance_to(
+				   listener->get_global_position()) <= ls->cfg.max_refl_dist;
+}
+
+void SteamAudioServer::commit_scene_if_idle() {
+	if (!scene_dirty.load()) {
+		return;
+	}
+	if (is_refl_thread_processing.load()) {
+		SteamAudio::log(SteamAudio::log_debug,
+				"tick: commit deferred, reflections busy");
+		return;
+	}
+	iplSceneCommit(global_state.scene);
+	scene_dirty.store(false);
 	SteamAudio::log(SteamAudio::log_debug, "tick: committed scene");
+}
 
-	self->global_state.listener_coords =
-			ipl_coords_from(self->listener->get_global_transform());
-
-	for (auto ls : self->local_states) {
-		if (ls->src.player == nullptr) {
-			UtilityFunctions::push_warning(
-					"local state has empty player, not updating simulation state");
-			continue;
-		}
-		if (!ls->src.player->is_playing()) {
+void SteamAudioServer::process_direct_simulation() {
+	for (auto ls : local_states) {
+		if (!is_state_active(ls)) {
 			continue;
 		}
 
 		Vector3 src_pos = ls->src.player->get_global_position();
-		ls->dir_to_listener = src_pos - self->listener->get_global_position();
+		ls->dir_to_listener = src_pos - listener->get_global_position();
 
 		IPLDistanceAttenuationModel attn_model{};
 		attn_model.type = IPL_DISTANCEATTENUATIONTYPE_INVERSEDISTANCE;
@@ -96,20 +154,15 @@ void SteamAudioServer::tick() {
 	SteamAudio::log(SteamAudio::log_debug, "tick: direct inputs set");
 
 	IPLSimulationSharedInputs shared_inputs{};
-	shared_inputs.listener = self->global_state.listener_coords;
-	iplSimulatorSetSharedInputs(self->global_state.sim,
+	shared_inputs.listener = global_state.listener_coords;
+	iplSimulatorSetSharedInputs(global_state.sim,
 			IPL_SIMULATIONFLAGS_DIRECT, &shared_inputs);
-	iplSimulatorRunDirect(self->global_state.sim);
+	iplSimulatorRunDirect(global_state.sim);
 
 	SteamAudio::log(SteamAudio::log_debug, "tick: direct sim complete");
 
-	for (auto ls : self->local_states) {
-		if (ls->src.player == nullptr) {
-			UtilityFunctions::push_warning(
-					"local state has empty player, not updating simulation state");
-			continue;
-		}
-		if (!ls->src.player->is_playing()) {
+	for (auto ls : local_states) {
+		if (!is_state_active(ls)) {
 			continue;
 		}
 
@@ -117,43 +170,65 @@ void SteamAudioServer::tick() {
 		iplSourceGetOutputs(ls->src.src, IPL_SIMULATIONFLAGS_DIRECT, &outputs);
 		ls->direct_outputs = outputs.direct;
 	}
+}
 
-	if (is_refl_thread_processing.load()) {
-		SteamAudio::log(SteamAudio::log_debug, "tick: done, skipping reflections");
+void SteamAudioServer::fetch_reflection_outputs() {
+	global_state.refl_ir_lock.lock();
+
+	const bool have_baked = (loaded_probe_batch != nullptr && loaded_reverb_bytes > 0);
+
+	// After clearing baked reflections, skip fetching outputs briefly to let
+	// Steam Audio's background thread run a simulation cycle with realtime settings.
+	int ticks_remaining = ticks_after_clear.load();
+	if (ticks_remaining > 0) {
+		ticks_after_clear.store(ticks_remaining - 1);
+		for (auto ls : local_states) {
+			if (ls != nullptr) {
+				ls->refl_outputs.type = IPL_REFLECTIONEFFECTTYPE_CONVOLUTION;
+				ls->refl_outputs.ir = nullptr;
+				ls->refl_outputs.irSize = 0;
+			}
+		}
+		reverb_outputs_cache.type = IPL_REFLECTIONEFFECTTYPE_CONVOLUTION;
+		reverb_outputs_cache.ir = nullptr;
+		reverb_outputs_cache.irSize = 0;
+		global_state.refl_ir_lock.unlock();
 		return;
 	}
 
-	global_state.refl_ir_lock.lock();
 	for (auto ls : local_states) {
-		if (ls->src.player == nullptr) {
-			UtilityFunctions::push_warning(
-					"local state has empty player, not updating simulation state");
+		if (!is_state_active(ls)) {
 			continue;
 		}
-		if (!ls->src.player->is_playing()) {
-			continue;
-		}
-
-		if (ls->src.player->get_global_position().distance_to(listener->get_global_position()) > ls->cfg.max_refl_dist) {
+		if (!is_within_refl_range(ls)) {
 			continue;
 		}
 
+		// Fetch outputs from Steam Audio
 		IPLSimulationOutputs outputs;
 		iplSourceGetOutputs(ls->src.src, IPL_SIMULATIONFLAGS_REFLECTIONS, &outputs);
 		ls->refl_outputs = outputs.reflections;
 	}
-	global_state.refl_ir_lock.unlock();
 
-	for (auto ls : self->local_states) {
-		if (ls->src.player == nullptr) {
-			UtilityFunctions::push_warning(
-					"local state has empty player, not updating simulation state");
+	if (reverb_source != nullptr && have_baked) {
+		IPLSimulationOutputs ro{};
+		iplSourceGetOutputs(reverb_source, IPL_SIMULATIONFLAGS_REFLECTIONS, &ro);
+		reverb_outputs_cache = ro.reflections;
+	} else {
+		// No baked data or no reverb source - clear the cache
+		reverb_outputs_cache.type = IPL_REFLECTIONEFFECTTYPE_CONVOLUTION;
+		reverb_outputs_cache.ir = nullptr;
+		reverb_outputs_cache.irSize = 0;
+	}
+	global_state.refl_ir_lock.unlock();
+}
+
+void SteamAudioServer::prepare_reflection_inputs() {
+	for (auto ls : local_states) {
+		if (!is_state_active(ls)) {
 			continue;
 		}
-		if (!ls->src.player->is_playing()) {
-			continue;
-		}
-		if (ls->src.player->get_global_position().distance_to(listener->get_global_position()) > ls->cfg.max_refl_dist) {
+		if (!is_within_refl_range(ls)) {
 			continue;
 		}
 
@@ -173,26 +248,172 @@ void SteamAudioServer::tick() {
 		inputs.flags = IPL_SIMULATIONFLAGS_REFLECTIONS;
 		inputs.source = src_coords;
 
+		int refl_mode = listener->get_reflection_mode();
+
+		IPLBakedDataIdentifier baked_id{};
+		baked_id.type = IPL_BAKEDDATATYPE_REFLECTIONS;
+		baked_id.variation = IPL_BAKEDDATAVARIATION_REVERB;
+		baked_id.endpointInfluence.center = IPLVector3{ 0, 0, 0 };
+		baked_id.endpointInfluence.radius = 0.0f;
+
+		const bool have_reverb = (loaded_probe_batch != nullptr && loaded_reverb_bytes > 0);
+		const bool have_static = (loaded_probe_batch != nullptr);
+		const bool is_static_src = (player && player->is_baked_static_source());
+
+		bool use_global_reverb = false;
+		if (refl_mode == 1) {
+			inputs.baked = IPL_FALSE;
+		} else if (refl_mode == 2) {
+			if (have_reverb && reverb_source != nullptr) {
+				use_global_reverb = true;
+				inputs.baked = IPL_FALSE;
+			} else if (have_static && is_static_src) {
+				baked_id.variation = IPL_BAKEDDATAVARIATION_STATICSOURCE;
+				baked_id.endpointInfluence.center = ipl_vec3_from(src_pos);
+				baked_id.endpointInfluence.radius = baked_reflections ? baked_reflections->get_static_source_radius() : 1000.0f;
+				inputs.baked = IPL_TRUE;
+				inputs.bakedDataIdentifier = baked_id;
+			} else {
+				inputs.baked = IPL_FALSE;
+			}
+		} else {
+			if (have_static && is_static_src) {
+				baked_id.variation = IPL_BAKEDDATAVARIATION_STATICSOURCE;
+				baked_id.endpointInfluence.center = ipl_vec3_from(src_pos);
+				baked_id.endpointInfluence.radius = baked_reflections ? baked_reflections->get_static_source_radius() : 1000.0f;
+				inputs.baked = IPL_TRUE;
+				inputs.bakedDataIdentifier = baked_id;
+			} else if (have_reverb && reverb_source != nullptr) {
+				use_global_reverb = true;
+				inputs.baked = IPL_FALSE;
+			} else {
+				inputs.baked = IPL_FALSE;
+			}
+		}
+
+		// Track whether this source is using global baked reverb for stream.cpp
+		ls->using_global_reverb = use_global_reverb;
+
+		if (use_global_reverb) {
+			// Populate per-band reverbScale from the direct sim transmission[] where available.
+			// IPL defines IPL_NUM_BANDS bands; use per-band smoothing to avoid artifacts.
+			const float rate_per_sec = 6.0f; // smoothing speed (tune as needed)
+			const float dt = 1.0f / 60.0f; // approximate tick interval; replace with real delta if available
+			const float gate_thresh = 0.001f; // smaller gate to avoid audible abrupt silence
+			float overall_transmission = 1.0f;
+			bool have_band_trans = false;
+			for (int b = 0; b < IPL_NUM_BANDS; ++b) {
+				float band_trans = 1.0f;
+				// If transmission[] exists on direct_outputs, use it. Otherwise use occlusion scalar.
+				band_trans = ls->direct_outputs.transmission[b];
+				have_band_trans = true;
+				// Smooth each band
+				ls->reverb_send_band_gain[b] += (band_trans - ls->reverb_send_band_gain[b]) * std::min(1.0f, rate_per_sec * dt);
+				inputs.reverbScale[b] = ls->reverb_send_band_gain[b];
+				overall_transmission += ls->reverb_send_band_gain[b];
+			}
+			if (!have_band_trans) {
+				// Fallback to occlusion scalar
+				float transmission = 1.0f - ls->direct_outputs.occlusion;
+				ls->reverb_send_gain += (transmission - ls->reverb_send_gain) * std::min(1.0f, rate_per_sec * dt);
+				if (ls->reverb_send_gain <= gate_thresh) {
+					// Zero the reverbScale to effectively gate baked reverb
+					for (int b = 0; b < IPL_NUM_BANDS; ++b)
+						inputs.reverbScale[b] = 0.0f;
+				} else {
+					for (int b = 0; b < IPL_NUM_BANDS; ++b)
+						inputs.reverbScale[b] = ls->reverb_send_gain;
+				}
+			} else {
+				// If all bands very small, treat as gated.
+				overall_transmission /= float(IPL_NUM_BANDS);
+				if (overall_transmission <= gate_thresh) {
+					for (int b = 0; b < IPL_NUM_BANDS; ++b)
+						inputs.reverbScale[b] = 0.0f;
+				}
+			}
+			// Apply cached reverb IR; per-band scaling is provided in inputs.reverbScale.
+			ls->refl_outputs = reverb_outputs_cache;
+		}
+
+		if (debug_log_refl_usage) {
+			if ((debug_log_frame_counter % std::max(1, debug_log_interval_frames)) == 0) {
+				String src_name = ls->src.player->get_name();
+				const char *mode_str = (refl_mode == 2) ? "BAKED" : (refl_mode == 1 ? "REALTIME" : "AUTO");
+				if (inputs.baked == IPL_TRUE) {
+					if (baked_id.variation == IPL_BAKEDDATAVARIATION_STATICSOURCE) {
+						SteamAudio::log(SteamAudio::log_debug, "(" + String(mode_str) + ") Reflections for source " + src_name + " [static=" + String(is_static_src ? "true" : "false") + "]: BAKED (STATICSOURCE), radius=" + String::num_real(baked_reflections ? baked_reflections->get_static_source_radius() : 1000.0f) + ", layer bytes=" + String::num_int64((int64_t)loaded_static_bytes));
+					} else {
+						SteamAudio::log(SteamAudio::log_debug, "(" + String(mode_str) + ") Reflections for source " + src_name + " [static=" + String(is_static_src ? "true" : "false") + "]: BAKED (REVERB) — via global reverb source, layer bytes=" + String::num_int64((int64_t)loaded_reverb_bytes));
+					}
+				} else {
+					const char *reason = (use_global_reverb)
+							? "global reverb in use"
+							: ((loaded_probe_batch == nullptr)
+											  ? "no probe batch"
+											  : ((loaded_reverb_bytes <= 0 &&
+														 loaded_static_bytes <= 0)
+																? "no baked layers"
+																: (refl_mode == 1
+																				  ? "forced realtime"
+																				  : (!is_static_src && have_static
+																									? "source not marked static"
+																									: "fallback"))));
+					SteamAudio::log(SteamAudio::log_debug, "(" + String(mode_str) + ") Reflections for source " + src_name + " [static=" + String(is_static_src ? "true" : "false") + "]: REALTIME (" + String(reason) + ")");
+				}
+			}
+		}
+
 		iplSourceSetInputs(ls->src.src, IPL_SIMULATIONFLAGS_REFLECTIONS, &inputs);
 	}
+}
 
-	shared_inputs = IPLSimulationSharedInputs{};
+void SteamAudioServer::prepare_reverb_inputs() {
+	if (reverb_source == nullptr) {
+		return;
+	}
+
+	IPLSimulationInputs reverb_inputs{};
+	reverb_inputs.flags = IPL_SIMULATIONFLAGS_REFLECTIONS;
+	reverb_inputs.source = global_state.listener_coords;
+	if (loaded_probe_batch != nullptr && loaded_reverb_bytes > 0) {
+		reverb_inputs.baked = IPL_TRUE;
+		IPLBakedDataIdentifier rid{};
+		rid.type = IPL_BAKEDDATATYPE_REFLECTIONS;
+		rid.variation = IPL_BAKEDDATAVARIATION_REVERB;
+		rid.endpointInfluence.center = IPLVector3{ 0, 0, 0 };
+		rid.endpointInfluence.radius = 0.0f;
+		reverb_inputs.bakedDataIdentifier = rid;
+	} else {
+		reverb_inputs.baked = IPL_FALSE;
+	}
+	iplSourceSetInputs(reverb_source, IPL_SIMULATIONFLAGS_REFLECTIONS, &reverb_inputs);
+}
+
+void SteamAudioServer::configure_reflection_shared_inputs() {
+	IPLSimulationSharedInputs shared_inputs{};
 	shared_inputs.listener = global_state.listener_coords;
 	shared_inputs.numRays = listener->get_num_refl_rays();
 	shared_inputs.numBounces = listener->get_num_refl_bounces();
 	shared_inputs.duration = listener->get_refl_duration();
 	shared_inputs.order = listener->get_refl_ambisonics_order();
 	shared_inputs.irradianceMinDistance = listener->get_irradiance_min_dist();
-	iplSimulatorSetSharedInputs(global_state.sim, IPL_SIMULATIONFLAGS_REFLECTIONS, &shared_inputs);
+	iplSimulatorSetSharedInputs(global_state.sim, IPL_SIMULATIONFLAGS_REFLECTIONS,
+			&shared_inputs);
+}
 
-	{
-		// notify reflection thread and tell it it can start running again
-		std::unique_lock<std::mutex> lock(refl_mux);
-		is_refl_thread_processing.store(true);
-		cv.notify_one();
-	}
+void SteamAudioServer::wake_reflection_worker() {
+	std::unique_lock<std::mutex> lock(refl_mux);
+	is_refl_thread_processing.store(true);
+	cv.notify_one();
+}
 
-	SteamAudio::log(SteamAudio::log_debug, "tick: done");
+void SteamAudioServer::mark_scene_dirty() {
+	scene_dirty.store(true);
+}
+
+void SteamAudioServer::notify_scene_dirty() {
+	mark_scene_dirty();
 }
 
 GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
@@ -218,6 +439,12 @@ GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
 	global_state.scene = iplSceneRetain(global_state.scene);
 	for (auto m : static_meshes_to_add) {
 		iplStaticMeshAdd(m, global_state.scene);
+		registered_static_meshes.push_back(m);
+	}
+	// Commit the scene now so geometry is available for reflection simulation
+	if (!static_meshes_to_add.empty()) {
+		iplSceneCommit(global_state.scene);
+		SteamAudio::log(SteamAudio::log_info, "Committed scene with " + String::num_int64(static_meshes_to_add.size()) + " static meshes.");
 	}
 
 	global_state.sim = create_simulator(
@@ -235,16 +462,81 @@ GlobalSteamAudioState *SteamAudioServer::get_global_state(bool should_init) {
 	init_mux.unlock();
 
 	SteamAudio::log(SteamAudio::log_info, "Initialized SteamAudioServer global state");
+
 	start_refl_sim();
+
+	// Create dedicated reverb source (listener-centric) for baked REVERB queries.
+	{
+		IPLSourceSettings src_cfg{};
+		src_cfg.flags = IPL_SIMULATIONFLAGS_REFLECTIONS;
+		IPLerror st = iplSourceCreate(global_state.sim, &src_cfg, &reverb_source);
+		handleErr(st);
+		if (st == IPL_STATUS_SUCCESS && reverb_source != nullptr) {
+			iplSourceAdd(reverb_source, global_state.sim);
+			iplSimulatorCommit(global_state.sim);
+			SteamAudio::log(SteamAudio::log_info, "Created dedicated reverb source for listener-centric baked REVERB.");
+		} else {
+			UtilityFunctions::push_warning("[Steam Audio] Failed to create dedicated reverb source; baked REVERB will be unavailable.");
+		}
+	}
+
+	// If a baker node already provided baked data before init, load it now.
+	if (baked_reflections && baked_reflections->baked_data.is_valid()) {
+		SteamAudio::log(SteamAudio::log_info, "Global state ready; attempting to load baked reflections into simulator.");
+		set_baked_reflections(baked_reflections);
+	} else {
+		// Attempt auto-discovery of a SteamAudioBakedReflections node in the current scene tree.
+		SteamAudioBakedReflections *found_baker = nullptr;
+		if (Engine::get_singleton()) {
+			SceneTree *tree = Engine::get_singleton()->get_main_loop() ? Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop()) : nullptr;
+			Window *root_window = tree ? tree->get_root() : nullptr;
+			Node *root = root_window ? Object::cast_to<Node>(root_window) : nullptr;
+			if (root) {
+				// DFS to find first SteamAudioBakedReflections
+				std::function<void(Node *)> dfs = [&](Node *n) {
+					if (found_baker || !n)
+						return;
+					if (auto *baker_node = Object::cast_to<SteamAudioBakedReflections>(n)) {
+						found_baker = baker_node;
+						return;
+					}
+					const int cc = n->get_child_count();
+					for (int i = 0; i < cc; ++i) {
+						dfs(n->get_child(i));
+						if (found_baker)
+							return;
+					}
+				};
+				dfs(root);
+			}
+		}
+
+		if (found_baker) {
+			SteamAudio::log(SteamAudio::log_info, "Found SteamAudioBakedReflections node in scene; attempting to load baked data.");
+			set_baked_reflections(found_baker);
+		} else {
+			SteamAudio::log(SteamAudio::log_info, "Global state ready; no baked reflections resource assigned yet.");
+			SteamAudio::log(SteamAudio::log_info, "Hint: Add a SteamAudioBakedReflections node to your scene and assign a SteamAudioBakedReflectionData resource to auto-load bakes on play.");
+		}
+	}
 	return &global_state;
 }
 
 void SteamAudioServer::start_refl_sim() {
-	refl_thread.instantiate();
-	refl_thread->start(callable_mp(this, &SteamAudioServer::run_refl_sim));
+	if (!refl_thread.is_valid()) {
+		refl_thread.instantiate();
+		SteamAudio::log(SteamAudio::log_debug, "Created reflections Thread object " + String::num_int64(reinterpret_cast<int64_t>(refl_thread.ptr())));
+	}
+	if (!refl_thread_started.load() && refl_thread.is_valid()) {
+		const bool in_editor = Engine::get_singleton() && Engine::get_singleton()->is_editor_hint();
+		SteamAudio::log(SteamAudio::log_debug, "Starting reflections worker (in_editor=" + String(in_editor ? "true" : "false") + ") started_flag=" + String(refl_thread_started.load() ? "true" : "false") + ")");
+		refl_thread->start(callable_mp(this, &SteamAudioServer::run_refl_sim));
+		refl_thread_started.store(true);
+	}
 }
 
 void SteamAudioServer::run_refl_sim() {
+	SteamAudio::log(SteamAudio::log_debug, "run_refl_sim() ENTER (self=" + String::num_int64(reinterpret_cast<int64_t>(this)) + ")");
 	while (this->is_running.load()) {
 		{
 			std::unique_lock<std::mutex> lock(this->refl_mux);
@@ -262,6 +554,7 @@ void SteamAudioServer::run_refl_sim() {
 		iplSimulatorRunReflections(global_state.sim);
 		is_refl_thread_processing.store(false);
 	}
+	SteamAudio::log(SteamAudio::log_debug, "run_refl_sim() EXIT (is_running=false)");
 }
 
 void SteamAudioServer::add_listener(SteamAudioListener *lis) {
@@ -284,6 +577,8 @@ void SteamAudioServer::remove_local_state(LocalSteamAudioState *ls) {
 void SteamAudioServer::add_static_mesh(IPLStaticMesh mesh) {
 	if (is_global_state_init.load()) {
 		iplStaticMeshAdd(mesh, global_state.scene);
+		registered_static_meshes.push_back(mesh);
+		mark_scene_dirty();
 	} else {
 		static_meshes_to_add.push_back(mesh);
 	}
@@ -292,6 +587,11 @@ void SteamAudioServer::add_static_mesh(IPLStaticMesh mesh) {
 void SteamAudioServer::remove_static_mesh(IPLStaticMesh mesh) {
 	if (is_global_state_init.load()) {
 		iplStaticMeshRemove(mesh, global_state.scene);
+		auto it2 = std::find(registered_static_meshes.begin(), registered_static_meshes.end(), mesh);
+		if (it2 != registered_static_meshes.end()) {
+			registered_static_meshes.erase(it2);
+		}
+		mark_scene_dirty();
 	} else {
 		// Probably won't happen?
 		auto it = std::find(static_meshes_to_add.begin(), static_meshes_to_add.end(), mesh);
@@ -304,6 +604,7 @@ void SteamAudioServer::remove_static_mesh(IPLStaticMesh mesh) {
 void SteamAudioServer::add_dynamic_mesh(IPLInstancedMesh mesh) {
 	if (is_global_state_init.load()) {
 		iplInstancedMeshAdd(mesh, global_state.scene);
+		mark_scene_dirty();
 	} else {
 		SteamAudio::log(SteamAudio::log_error, "Adding a dynamic mesh, but SteamAudio is not initialized. Probably crashing soon.");
 	}
@@ -315,6 +616,232 @@ void SteamAudioServer::remove_dynamic_mesh(IPLInstancedMesh mesh) {
 	}
 
 	iplInstancedMeshRemove(mesh, global_state.scene);
+	mark_scene_dirty();
+}
+
+void SteamAudioServer::clear_baked_reflections(SteamAudioBakedReflections *node) {
+	// Only clear if this is the currently active baked reflections node
+	if (node != nullptr && this->baked_reflections != node) {
+		return;
+	}
+
+	this->baked_reflections = nullptr;
+
+	if (!is_global_state_init.load()) {
+		return;
+	}
+
+	// Wait for reflection sim to be idle
+	int spins = 0;
+	while (is_refl_thread_processing.load() && spins < 200) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+		++spins;
+	}
+
+	std::unique_lock<std::mutex> refl_lock(refl_mux);
+
+	// Remove probe batch from simulator
+	if (loaded_probe_batch != nullptr && global_state.sim != nullptr) {
+		iplSimulatorRemoveProbeBatch(global_state.sim, loaded_probe_batch);
+		iplSimulatorCommit(global_state.sim);
+		iplProbeBatchRelease(&loaded_probe_batch);
+		loaded_probe_batch = nullptr;
+		loaded_reverb_bytes = 0;
+		loaded_static_bytes = 0;
+	}
+
+	global_state.refl_ir_lock.lock();
+
+	// Remove and re-add all sources to force Steam Audio to clear internal cached state
+	std::vector<IPLSource> sources_to_readd;
+	for (auto ls : local_states) {
+		if (ls != nullptr && ls->src.src != nullptr) {
+			sources_to_readd.push_back(ls->src.src);
+			iplSourceRemove(ls->src.src, global_state.sim);
+		}
+	}
+	if (reverb_source != nullptr) {
+		sources_to_readd.push_back(reverb_source);
+		iplSourceRemove(reverb_source, global_state.sim);
+	}
+	iplSimulatorCommit(global_state.sim);
+
+	for (auto src : sources_to_readd) {
+		iplSourceAdd(src, global_state.sim);
+	}
+	iplSimulatorCommit(global_state.sim);
+
+	// Reset all local states and their effects
+	for (auto ls : local_states) {
+		if (ls == nullptr)
+			continue;
+
+		// Clear cached reflection outputs
+		ls->refl_outputs.type = IPL_REFLECTIONEFFECTTYPE_CONVOLUTION;
+		ls->refl_outputs.ir = nullptr;
+		ls->refl_outputs.irSize = 0;
+		ls->reverb_send_gain = 1.0f;
+		for (int b = 0; b < IPL_NUM_BANDS; ++b) {
+			ls->reverb_send_band_gain[b] = 1.0f;
+		}
+		ls->using_global_reverb = false;
+
+		// Reset reflection effects to flush convolution buffers
+		if (ls->fx.refl != nullptr) {
+			iplReflectionEffectReset(ls->fx.refl);
+		}
+		if (ls->fx.refl_param != nullptr) {
+			iplReflectionEffectReset(ls->fx.refl_param);
+		}
+
+		// Zero audio buffers to remove lingering reverb samples
+		if (ls->bufs.refl_out.data != nullptr) {
+			for (int ch = 0; ch < ls->bufs.refl_out.numChannels; ++ch) {
+				if (ls->bufs.refl_out.data[ch] != nullptr) {
+					memset(ls->bufs.refl_out.data[ch], 0, ls->bufs.refl_out.numSamples * sizeof(float));
+				}
+			}
+		}
+		if (ls->bufs.refl_ambi.data != nullptr) {
+			for (int ch = 0; ch < ls->bufs.refl_ambi.numChannels; ++ch) {
+				if (ls->bufs.refl_ambi.data[ch] != nullptr) {
+					memset(ls->bufs.refl_ambi.data[ch], 0, ls->bufs.refl_ambi.numSamples * sizeof(float));
+				}
+			}
+		}
+
+		// Set source to realtime mode
+		if (ls->src.src != nullptr) {
+			IPLSimulationInputs inputs{};
+			inputs.flags = IPL_SIMULATIONFLAGS_REFLECTIONS;
+			Vector3 src_pos = ls->src.player ? ls->src.player->get_global_position() : Vector3();
+			IPLCoordinateSpace3 src_coords{};
+			src_coords.origin = ipl_vec3_from(src_pos);
+			inputs.source = src_coords;
+			inputs.baked = IPL_FALSE;
+			iplSourceSetInputs(ls->src.src, IPL_SIMULATIONFLAGS_REFLECTIONS, &inputs);
+		}
+	}
+
+	// Clear cached reverb outputs
+	reverb_outputs_cache.type = IPL_REFLECTIONEFFECTTYPE_CONVOLUTION;
+	reverb_outputs_cache.ir = nullptr;
+	reverb_outputs_cache.irSize = 0;
+
+	// Set reverb source to realtime mode
+	if (reverb_source != nullptr) {
+		IPLSimulationInputs reverb_inputs{};
+		reverb_inputs.flags = IPL_SIMULATIONFLAGS_REFLECTIONS;
+		reverb_inputs.source = global_state.listener_coords;
+		reverb_inputs.baked = IPL_FALSE;
+		iplSourceSetInputs(reverb_source, IPL_SIMULATIONFLAGS_REFLECTIONS, &reverb_inputs);
+	}
+
+	iplSimulatorCommit(global_state.sim);
+	iplSceneCommit(global_state.scene);
+	iplSimulatorSetScene(global_state.sim, global_state.scene);
+	iplSimulatorCommit(global_state.sim);
+
+	global_state.refl_ir_lock.unlock();
+
+	// Skip fetching outputs briefly to let Steam Audio run a simulation cycle
+	ticks_after_clear.store(5);
+}
+
+void SteamAudioServer::set_baked_reflections(SteamAudioBakedReflections *baked_reflections) {
+	this->baked_reflections = baked_reflections;
+
+	// If nullptr is passed, clear the current batch
+	if (baked_reflections == nullptr) {
+		if (is_global_state_init.load()) {
+			clear_baked_reflections(nullptr);
+		}
+		return;
+	}
+
+	if (!is_global_state_init.load()) {
+		// Defer loading baked data until global state is initialized to avoid null dereferences.
+		// Log only once at info level to avoid spam during editor reloads.
+		bool expected = false;
+		if (logged_baked_refl_deferral.compare_exchange_strong(expected, true)) {
+			SteamAudio::log(SteamAudio::log_info, "[godot-steam-audio] set_baked_reflections called before global state init; deferring load.");
+		}
+		return;
+	}
+
+	// Try to avoid races with the reflections simulation thread by waiting for it to be idle,
+	// then preventing it from starting while we modify probe batches.
+	int spins = 0;
+	while (is_refl_thread_processing.load() && spins < 200) { // up to ~1s
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+		++spins;
+	}
+	std::unique_lock<std::mutex> refl_lock(refl_mux);
+
+	// If a probe batch is already loaded, remove it first.
+	if (loaded_probe_batch != nullptr && global_state.sim != nullptr) {
+		SteamAudio::log(SteamAudio::log_info, "Removing previously loaded baked probe batch from simulator.");
+		iplSimulatorRemoveProbeBatch(global_state.sim, loaded_probe_batch);
+		iplSimulatorCommit(global_state.sim);
+		iplProbeBatchRelease(&loaded_probe_batch);
+		loaded_probe_batch = nullptr;
+		loaded_reverb_bytes = 0;
+		loaded_static_bytes = 0;
+	}
+
+	if (!(baked_reflections && baked_reflections->baked_data.is_valid())) {
+		UtilityFunctions::push_warning("[Steam Audio] No baked reflections data assigned; simulator will use real-time reflections only.");
+		return;
+	}
+
+	// Load probe batch from the serialized resource and add it to the simulator.
+	IPLSerializedObject serializedObject = baked_reflections->baked_data->get_data();
+	if (!serializedObject) {
+		UtilityFunctions::push_error("[Steam Audio] Baked reflections resource returned an empty serialized object.");
+		return;
+	}
+
+	const IPLsize bytes = iplSerializedObjectGetSize(serializedObject);
+	SteamAudio::log(SteamAudio::log_info, "Loading baked reflections from resource (" + String::num_int64(bytes) + " bytes).");
+
+	IPLerror status = iplProbeBatchLoad(global_state.ctx, serializedObject, &loaded_probe_batch);
+	if (status != IPL_STATUS_SUCCESS || loaded_probe_batch == nullptr) {
+		UtilityFunctions::push_error("[Steam Audio] Failed to load probe batch from baked data. Status: " + String::num_int64(status));
+		iplSerializedObjectRelease(&serializedObject);
+		loaded_probe_batch = nullptr;
+		return;
+	}
+
+	// We no longer need the serialized object after loading.
+	iplSerializedObjectRelease(&serializedObject);
+
+	// Report probe count and attach to simulator.
+	const int num_probes = iplProbeBatchGetNumProbes(loaded_probe_batch);
+	SteamAudio::log(SteamAudio::log_info, "Baked probe batch loaded. Probes: " + String::num_int64(num_probes));
+
+	// Ensure the probe batch is committed before adding to the simulator, mirroring Unity's flow.
+	iplProbeBatchCommit(loaded_probe_batch);
+
+	iplSimulatorAddProbeBatch(global_state.sim, loaded_probe_batch);
+	iplSimulatorCommit(global_state.sim);
+	SteamAudio::log(SteamAudio::log_info, "Baked reflections probe batch registered with simulator and committed.");
+
+	// Compute and log baked layer sizes for diagnostics (REVERB and STATICSOURCE).
+	IPLBakedDataIdentifier reverbId{};
+	reverbId.type = IPL_BAKEDDATATYPE_REFLECTIONS;
+	reverbId.variation = IPL_BAKEDDATAVARIATION_REVERB;
+	reverbId.endpointInfluence.center = IPLVector3{ 0, 0, 0 };
+	reverbId.endpointInfluence.radius = 0.0f;
+	loaded_reverb_bytes = iplProbeBatchGetDataSize(loaded_probe_batch, &reverbId);
+	SteamAudio::log(SteamAudio::log_info, "REVERB layer size in loaded probe batch: " + String::num_int64((int64_t)loaded_reverb_bytes) + " bytes");
+
+	IPLBakedDataIdentifier staticId{};
+	staticId.type = IPL_BAKEDDATATYPE_REFLECTIONS;
+	staticId.variation = IPL_BAKEDDATAVARIATION_STATICSOURCE;
+	staticId.endpointInfluence.center = IPLVector3{ 0, 0, 0 };
+	staticId.endpointInfluence.radius = 0.0f;
+	loaded_static_bytes = iplProbeBatchGetDataSize(loaded_probe_batch, &staticId);
+	SteamAudio::log(SteamAudio::log_info, "STATICSOURCE layer size in loaded probe batch: " + String::num_int64((int64_t)loaded_static_bytes) + " bytes");
 }
 
 SteamAudioServer::SteamAudioServer() {
@@ -323,17 +850,50 @@ SteamAudioServer::SteamAudioServer() {
 	is_refl_thread_processing.store(false);
 	is_running.store(true);
 	local_states_have_changed.store(false);
+	scene_dirty.store(false);
+	SteamAudio::log(SteamAudio::log_debug, "SteamAudioServer() constructed (this=" + String::num_int64(reinterpret_cast<int64_t>(this)) + ", in_editor=" + String(Engine::get_singleton() && Engine::get_singleton()->is_editor_hint() ? "true" : "false") + ")");
 }
 
 SteamAudioServer::~SteamAudioServer() {
+	// Stop the reflections worker thread cleanly.
 	is_running.store(false);
-	refl_thread->wait_to_finish();
-	refl_thread.unref();
+	// Wake the worker if it's blocked on the condition variable so it can exit.
+	{
+		std::unique_lock<std::mutex> lock(refl_mux);
+		cv.notify_all();
+	}
+	if (refl_thread.is_valid()) {
+		// Godot requires calling wait_to_finish() on any thread that was ever started,
+		// even if it has already finished. Track this explicitly to avoid warnings.
+		SteamAudio::log(SteamAudio::log_debug, "~SteamAudioServer: Thread ptr=" + String::num_int64(reinterpret_cast<int64_t>(refl_thread.ptr())) + ", started_flag=" + String(refl_thread_started.load() ? "true" : "false") + ", is_started()=" + String(refl_thread->is_started() ? "true" : "false") + ", is_alive()=" + String(refl_thread->is_alive() ? "true" : "false"));
+		if (refl_thread_started.load()) {
+			refl_thread->wait_to_finish();
+		}
+		refl_thread.unref();
+	}
 
 	if (!self->is_global_state_init.load()) {
+		SteamAudio::log(SteamAudio::log_debug, "~SteamAudioServer: global state not initialized; skipping audio cleanup.");
 		return;
 	}
 	SteamAudio::log(SteamAudio::log_debug, "destroying steam audio server");
+
+	// Clean up dedicated reverb source.
+	if (reverb_source != nullptr) {
+		iplSourceRemove(reverb_source, global_state.sim);
+		iplSimulatorCommit(global_state.sim);
+		iplSourceRelease(&reverb_source);
+		reverb_source = nullptr;
+	}
+
+	// Clean up any loaded baked probe batch from simulator.
+	if (loaded_probe_batch != nullptr) {
+		SteamAudio::log(SteamAudio::log_info, "Releasing baked probe batch from simulator during shutdown.");
+		iplSimulatorRemoveProbeBatch(global_state.sim, loaded_probe_batch);
+		iplSimulatorCommit(global_state.sim);
+		iplProbeBatchRelease(&loaded_probe_batch);
+		loaded_probe_batch = nullptr;
+	}
 
 	iplAmbisonicsDecodeEffectRelease(&self->global_state.ambi_dec_effect);
 	iplAmbisonicsEncodeEffectRelease(&self->global_state.ambi_enc_effect);
@@ -354,3 +914,13 @@ SteamAudioServer *SteamAudioServer::get_singleton() {
 }
 
 SteamAudioServer *SteamAudioServer::self = nullptr;
+
+void SteamAudioServer::debug_dump_scene_geometry() {
+	SteamAudio::log(SteamAudio::log_debug, "Global init:" + String(is_global_state_init.load() ? "true" : "false"));
+	SteamAudio::log(SteamAudio::log_debug, "Context ptr:" + String::num_int64(reinterpret_cast<int64_t>(global_state.ctx)));
+	SteamAudio::log(SteamAudio::log_debug, "Scene ptr:" + String::num_int64(reinterpret_cast<int64_t>(global_state.scene)));
+	SteamAudio::log(SteamAudio::log_debug, "Simulator ptr:" + String::num_int64(reinterpret_cast<int64_t>(global_state.sim)));
+	SteamAudio::log(SteamAudio::log_debug, "Queued static meshes:" + String::num_int64(static_meshes_to_add.size()));
+	SteamAudio::log(SteamAudio::log_debug, "Registered static meshes:" + String::num_int64(registered_static_meshes.size()));
+	SteamAudio::log(SteamAudio::log_debug, "Queued dynamic meshes:" + String::num_int64(dynamic_meshes_to_add.size()));
+}

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -1,7 +1,9 @@
 #ifndef STEAM_AUDIO_SERVER_H
 #define STEAM_AUDIO_SERVER_H
 
+#include "baked_reflections.hpp"
 #include "godot_cpp/classes/object.hpp"
+#include "godot_cpp/classes/ref.hpp"
 #include "godot_cpp/classes/thread.hpp"
 #include "listener.hpp"
 #include "steam_audio.hpp"
@@ -23,21 +25,63 @@ private:
 	std::atomic<bool> is_refl_thread_processing;
 	std::atomic<bool> is_running;
 	std::atomic<bool> local_states_have_changed;
+	std::atomic<bool> scene_dirty;
+	std::atomic<int> ticks_after_clear{ 0 }; // Skip fetching outputs briefly after clearing baked reflections
 	std::mutex init_mux;
 	std::mutex refl_mux;
 	std::condition_variable cv;
 
 	// meshes to add to the global state scene after it's initialized.
 	std::vector<IPLStaticMesh> static_meshes_to_add;
+	// meshes that have already been added to the scene (tracked for debugging)
+	std::vector<IPLStaticMesh> registered_static_meshes;
 	std::vector<IPLStaticMesh> dynamic_meshes_to_add;
 
 	// TODO: allow for multiple
 	SteamAudioListener *listener = nullptr;
 
+	SteamAudioBakedReflections *baked_reflections = nullptr;
+
+	// Handle to the currently loaded baked probe batch (if any).
+	IPLProbeBatch loaded_probe_batch = nullptr;
+
+	// Diagnostics: size of baked layers in the currently loaded probe batch.
+	IPLsize loaded_reverb_bytes = 0;
+	IPLsize loaded_static_bytes = 0;
+
+	// Debug logging controls for reflections usage reporting.
+	bool debug_log_refl_usage = true;
+	int debug_log_frame_counter = 0;
+	int debug_log_interval_frames = 60;
+
+	// One-time log guard to avoid spamming when set_baked_reflections is called
+	// before the global state has been initialized.
+	std::atomic<bool> logged_baked_refl_deferral{ false };
+
+	// Dedicated source used to query baked REVERB (listener-centric)
+	IPLSource reverb_source = nullptr;
+	// Cached reverb outputs retrieved from reverb_source each tick
+	IPLReflectionEffectParams reverb_outputs_cache{ {} };
+
 	void init_scene(IPLSceneSettings *scene_cfg);
 	void start_refl_sim();
 	void run_refl_sim();
-	Ref<Thread> refl_thread;
+	Ref<Thread> refl_thread; // Hold as Ref to match Godot's RefCounted lifecycle
+	std::atomic<bool> refl_thread_started{ false };
+	// Runtime toggle to disable the reflections worker thread for diagnostics.
+	bool enable_refl_worker = true;
+
+	bool is_tick_ready() const;
+	bool is_state_active(LocalSteamAudioState *ls) const;
+	bool is_within_refl_range(LocalSteamAudioState *ls) const;
+	void commit_scene_if_idle();
+	void process_direct_simulation();
+	void fetch_reflection_outputs();
+	void prepare_reflection_inputs();
+	void prepare_reverb_inputs();
+	void configure_reflection_shared_inputs();
+	void wake_reflection_worker();
+	void mark_scene_dirty();
 
 protected:
 	static void _bind_methods();
@@ -56,8 +100,14 @@ public:
 	void remove_static_mesh(IPLStaticMesh mesh);
 	void add_dynamic_mesh(IPLInstancedMesh mesh);
 	void remove_dynamic_mesh(IPLInstancedMesh mesh);
+	void set_baked_reflections(SteamAudioBakedReflections *baked_reflections);
+	void clear_baked_reflections(SteamAudioBakedReflections *node);
+	void notify_scene_dirty();
 
 	void tick();
+
+	// Debug helpers
+	void debug_dump_scene_geometry();
 };
 
 #endif // STEAM_AUDIO_SERVER_H

--- a/src/steam_audio.cpp
+++ b/src/steam_audio.cpp
@@ -2,7 +2,7 @@
 #include "config.hpp"
 #include "godot_cpp/variant/utility_functions.hpp"
 
-void SteamAudio::log(GodotSteamAudioLogLevel lvl, const char *str) {
+void SteamAudio::log(GodotSteamAudioLogLevel lvl, const String &str) {
 	if (lvl < SteamAudioConfig::log_level) {
 		return;
 	}

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -21,7 +21,7 @@ public:
 		log_error
 	} GodotSteamAudioLogLevel;
 
-	static void log(GodotSteamAudioLogLevel lvl, const char *str);
+	static void log(GodotSteamAudioLogLevel lvl, const String &str);
 };
 
 struct GlobalSteamAudioState {
@@ -63,6 +63,8 @@ struct SteamAudioSourceConfig {
 struct SteamAudioEffects {
 	IPLDirectEffect direct;
 	IPLReflectionEffect refl;
+	// Dedicated effect instance for PARAMETRIC reflection output (reverb)
+	IPLReflectionEffect refl_param;
 	IPLAmbisonicsDecodeEffect dec;
 	IPLAmbisonicsDecodeEffect refl_dec;
 	IPLAmbisonicsEncodeEffect enc;
@@ -86,6 +88,14 @@ struct LocalSteamAudioState {
 	LocalSteamAudioBuffers bufs;
 	SteamAudioEffects fx;
 	SteamAudioSourceConfig cfg;
+	// Smoothed gain used to scale the contribution of listener-centric baked REVERB
+	// for this source. Driven from direct-simulation transmission (0..1).
+	float reverb_send_gain = 1.0f;
+	// Per-band smoothed gains (match IPL_NUM_BANDS) for frequency-aware scaling.
+	float reverb_send_band_gain[IPL_NUM_BANDS] = { 1.0f };
+	// True when reflections are coming from global baked reverb (needs transmission attenuation).
+	// False for realtime reflections (no attenuation needed - already ray-traced).
+	bool using_global_reverb = false;
 	std::shared_mutex mux;
 };
 
@@ -93,8 +103,20 @@ inline int ambisonic_channels_from(int order) {
 	return (order + 1) * (order + 1);
 }
 
+// NOTE:
+// We must convert Godot math types to Steam Audio (IPL) types explicitly.
+// - Godot uses Vector3 with forward = -Z. Steam Audio expects plain float triplets
+//   (IPLVector3) with no implicit handedness conversion. The numeric values are the
+//   same, so this helper exists purely to avoid repeating boilerplate and to keep
+//   call sites clear.
 inline IPLVector3 ipl_vec3_from(Vector3 v) { return IPLVector3{ v.x, v.y, v.z }; }
 
+// NOTE:
+// Steam Audio needs an explicit coordinate frame (origin, right, up, ahead).
+// Godot's basis columns are: X = right, Y = up, Z = forward (but forward is -Z in Godot).
+// Therefore, we must negate the Z column to produce the "ahead" vector that Steam Audio
+// expects. This small transform is required for correct spatialization and is not
+// redundant with any Steam Audio API. Removing or skipping this will flip directions.
 inline IPLCoordinateSpace3 ipl_coords_from(Transform3D trf) {
 	auto orig = trf.origin;
 	auto right = trf.get_basis().get_column(0);
@@ -108,6 +130,45 @@ inline IPLCoordinateSpace3 ipl_coords_from(Transform3D trf) {
 	coords.ahead = ipl_vec3_from(fwd);
 
 	return coords;
+}
+
+// Build an IPLMatrix4x4 from a Godot Transform3D.
+// Context and layout notes:
+// - IPLMatrix4x4 is documented as "row-major order" in phonon.h, but this refers to memory
+//   layout (elements[row][col]). The mathematical convention is column-major (basis vectors
+//   are columns), confirmed by Steam Audio passing matrices to Embree as COLUMN_MAJOR.
+// - Godot's Transform3D conceptually has basis vectors as columns, but stores them transposed
+//   internally (basis.rows[]) for performance (see godot-cpp basis.hpp:169).
+// - Therefore, we can directly copy Godot's internal rows as IPL matrix columns (which are
+//   stored row-major in memory but represent a column-major transform mathematically).
+inline IPLMatrix4x4 ipl_matrix_from(const Transform3D &xf) {
+	// Godot's basis.rows[i] is actually the i-th basis column vector stored for performance.
+	// We copy these directly as columns in the IPL matrix.
+	const Basis &b = xf.basis;
+	const Vector3 &t = xf.origin;
+
+	IPLMatrix4x4 M{};
+	// Column 0: X-axis (right)
+	M.elements[0][0] = b.rows[0][0];
+	M.elements[1][0] = b.rows[0][1];
+	M.elements[2][0] = b.rows[0][2];
+	M.elements[3][0] = 0.f;
+	// Column 1: Y-axis (up)
+	M.elements[0][1] = b.rows[1][0];
+	M.elements[1][1] = b.rows[1][1];
+	M.elements[2][1] = b.rows[1][2];
+	M.elements[3][1] = 0.f;
+	// Column 2: Z-axis (forward)
+	M.elements[0][2] = b.rows[2][0];
+	M.elements[1][2] = b.rows[2][1];
+	M.elements[2][2] = b.rows[2][2];
+	M.elements[3][2] = 0.f;
+	// Column 3: Translation
+	M.elements[0][3] = t.x;
+	M.elements[1][3] = t.y;
+	M.elements[2][3] = t.z;
+	M.elements[3][3] = 1.f;
+	return M;
 }
 
 inline void handleErr(IPLerror err) {
@@ -142,7 +203,7 @@ inline void log_callback(IPLLogLevel level, const char *message) {
 			godot_log_level = SteamAudio::GodotSteamAudioLogLevel::log_debug;
 			break;
 	}
-	SteamAudio::log(godot_log_level, String(message).strip_edges().utf8().get_data());
+	SteamAudio::log(godot_log_level, String(message).strip_edges());
 }
 
 #endif

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -10,7 +10,10 @@
 #include <godot_cpp/core/property_info.hpp>
 
 SteamAudioStream::SteamAudioStream() {}
-SteamAudioStream::~SteamAudioStream() {}
+SteamAudioStream::~SteamAudioStream() {
+	// Ensure we don't hold on to an inner stream at destruction.
+	stream = Ref<AudioStream>();
+}
 
 void SteamAudioStream::_bind_methods() {}
 
@@ -30,7 +33,11 @@ Ref<AudioStream> SteamAudioStream::get_stream() { return this->stream; }
 // SteamAudioStreamPlayback
 
 SteamAudioStreamPlayback::SteamAudioStreamPlayback() {}
-SteamAudioStreamPlayback::~SteamAudioStreamPlayback() {}
+SteamAudioStreamPlayback::~SteamAudioStreamPlayback() {
+	// Stop and release inner playback/stream to avoid leaks on quit.
+	_stop();
+	parent = nullptr;
+}
 
 int32_t SteamAudioStreamPlayback::_mix(AudioFrame *buffer, float rate_scale, int32_t frames) {
 	if (parent == nullptr) {
@@ -130,19 +137,58 @@ int32_t SteamAudioStreamPlayback::_mix(AudioFrame *buffer, float rate_scale, int
 	}
 
 	gs->refl_ir_lock.lock();
-	if (ls->refl_outputs.ir != nullptr && ls->cfg.is_reflection_on) {
+	if (ls->cfg.is_reflection_on) {
+		// Prepare mono input for reflections (both convolution and parametric expect mono in)
 		iplAudioBufferDownmix(gs->ctx, &ls->bufs.in, &ls->bufs.mono);
-		ls->refl_outputs.numChannels = ambisonic_channels_from(ls->cfg.ambisonics_order);
-		ls->refl_outputs.type = IPL_REFLECTIONEFFECTTYPE_CONVOLUTION;
-		ls->refl_outputs.irSize = int(SteamAudioConfig::max_refl_duration * float(gs->audio_cfg.samplingRate));
-		iplReflectionEffectApply(ls->fx.refl, &ls->refl_outputs, &ls->bufs.mono, &ls->bufs.refl_ambi, nullptr);
 
-		iplAmbisonicsDecodeEffectApply(
-				ls->fx.refl_dec, &dec_params,
-				&ls->bufs.refl_ambi, &ls->bufs.refl_out);
+		if (ls->refl_outputs.type == IPL_REFLECTIONEFFECTTYPE_CONVOLUTION) {
+			if (ls->refl_outputs.ir != nullptr && ls->refl_outputs.irSize > 0) {
+				iplReflectionEffectApply(ls->fx.refl, &ls->refl_outputs, &ls->bufs.mono, &ls->bufs.refl_ambi, nullptr);
+				iplAmbisonicsDecodeEffectApply(
+						ls->fx.refl_dec, &dec_params,
+						&ls->bufs.refl_ambi, &ls->bufs.refl_out);
 
-		SteamAudio::log(SteamAudio::log_debug, "mixing: mixing reflection and direct buffers");
-		iplAudioBufferMix(gs->ctx, &ls->bufs.refl_out, &ls->bufs.out);
+				SteamAudio::log(SteamAudio::log_debug, "mixing: mixing convolution reflections and direct buffers");
+
+				// Attenuate baked listener-centric reverb using transmission.
+				// Realtime reflections are already ray-traced through geometry and don't need this.
+				if (ls->using_global_reverb) {
+					// Compute overall gain from smoothed per-band transmission values
+					float sum = 0.0f;
+					float max_gain = 0.0f;
+					for (int b = 0; b < IPL_NUM_BANDS; ++b) {
+						sum += ls->reverb_send_band_gain[b];
+						if (ls->reverb_send_band_gain[b] > max_gain)
+							max_gain = ls->reverb_send_band_gain[b];
+					}
+					float mean_gain = sum / float(IPL_NUM_BANDS);
+					const float mean_weight = 0.8f;
+					float overall_gain = mean_gain * mean_weight + max_gain * (1.0f - mean_weight);
+
+					// Fallback to direct transmission if smoothed gains haven't converged
+					if (overall_gain >= 0.999f) {
+						float sum_t = 0.0f;
+						for (int b = 0; b < IPL_NUM_BANDS; ++b)
+							sum_t += ls->direct_outputs.transmission[b];
+						overall_gain = sum_t / float(IPL_NUM_BANDS);
+					}
+
+					// Scale reflection output in-place
+					if (overall_gain < 0.999f) {
+						for (int ch = 0; ch < ls->bufs.refl_out.numChannels; ++ch) {
+							for (int s = 0; s < ls->bufs.refl_out.numSamples; ++s) {
+								ls->bufs.refl_out.data[ch][s] *= overall_gain;
+							}
+						}
+					}
+				}
+				iplAudioBufferMix(gs->ctx, &ls->bufs.refl_out, &ls->bufs.out);
+			}
+		} else if (ls->refl_outputs.type == IPL_REFLECTIONEFFECTTYPE_PARAMETRIC) {
+			iplReflectionEffectApply(ls->fx.refl_param, &ls->refl_outputs, &ls->bufs.mono, &ls->bufs.refl_out, nullptr);
+			SteamAudio::log(SteamAudio::log_debug, "mixing: mixing parametric reflections and direct buffers");
+			iplAudioBufferMix(gs->ctx, &ls->bufs.refl_out, &ls->bufs.out);
+		}
 	}
 	gs->refl_ir_lock.unlock();
 
@@ -186,11 +232,19 @@ void SteamAudioStreamPlayback::_start(double from_pos) {
 }
 
 void SteamAudioStreamPlayback::_stop() {
+	// Mark inactive first to prevent further mixing.
 	is_active.store(false);
-	if (stream_playback == nullptr || !stream_playback->is_playing()) {
-		return;
+	if (stream_playback.is_valid()) {
+		if (stream_playback->is_playing()) {
+			stream_playback->stop();
+		}
+		// Release reference to the inner playback.
+		stream_playback = Ref<AudioStreamPlayback>();
 	}
-	stream_playback->stop();
+	// Also drop reference to the inner stream.
+	if (stream.is_valid()) {
+		stream = Ref<AudioStream>();
+	}
 }
 
 bool SteamAudioStreamPlayback::_is_playing() const { return is_active; }


### PR DESCRIPTION
I've tried to cleanup & refactor the branch, there is probably copilot garbage left. Unfortunately it's pretty big and it still has at least one problem.
I wasn't able to get a "native" bake button like in the `LightmapGI` node and had to do some gdscript stuff.  That's probably due to `godot-cpp` doesn't expose the editor stuff. There is still one problem left on windows that sometimes the bake instantly jumps to 100% without actually baking. That didn't happen on my mac.

closes #10 

credits also to @solitaryurt with the stale `baked-reflections` branch and the unity/unreal plugins.

Happy to get feedback & testing on this.