### PR TITLE
Add frequency-dependent transmission filtering

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -58,6 +58,9 @@ void SteamAudioPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "occlusion_radius", PROPERTY_HINT_RANGE, "0.0,20.0,0.1"), "set_occlusion_radius", "get_occlusion_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "occlusion_samples", PROPERTY_HINT_RANGE, "0,512,1"), "set_occlusion_samples", "get_occlusion_samples");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transmission_rays", PROPERTY_HINT_RANGE, "0,512,1"), "set_transmission_rays", "get_transmission_rays");
+	ClassDB::bind_method(D_METHOD("get_transmission_type"), &SteamAudioPlayer::get_transmission_type);
+	ClassDB::bind_method(D_METHOD("set_transmission_type", "p_transmission_type"), &SteamAudioPlayer::set_transmission_type);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "transmission_type", PROPERTY_HINT_ENUM, "Frequency-Independent,Frequency-Dependent"), "set_transmission_type", "get_transmission_type");
 
 	ADD_GROUP("Ambisonics", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ambisonics_order", PROPERTY_HINT_RANGE, "0,5,1"), "set_ambisonics_order", "get_ambisonics_order");
@@ -266,7 +269,7 @@ void SteamAudioPlayer::play_stream(const Ref<AudioStream> &p_stream, float p_fro
 	auto str = dynamic_cast<SteamAudioStream *>(get_stream().ptr());
 	if (str == nullptr) {
 		SteamAudio::log(SteamAudio::log_warn,
-				"Tried to get an inner stream from a SteamAudioPlayer, but its outer stream is not a SteamAudioStream. Returning null.");
+						"Tried to get an inner stream from a SteamAudioPlayer, but its outer stream is not a SteamAudioStream. Returning null.");
 		return;
 	}
 	str->set_stream(p_stream);
@@ -274,7 +277,7 @@ void SteamAudioPlayer::play_stream(const Ref<AudioStream> &p_stream, float p_fro
 	auto playback_ptr = dynamic_cast<SteamAudioStreamPlayback *>(get_stream_playback().ptr());
 	if (playback_ptr == nullptr) {
 		SteamAudio::log(SteamAudio::log_warn,
-				"Tried to play a new stream on SteamAudioPlayer, but this player's outer stream was not a SteamAudioStream. Will not play anything.");
+						"Tried to play a new stream on SteamAudioPlayer, but this player's outer stream was not a SteamAudioStream. Will not play anything.");
 		this->stop();
 		return;
 	}
@@ -286,7 +289,7 @@ Ref<AudioStream> SteamAudioPlayer::get_inner_stream() {
 	auto str = dynamic_cast<SteamAudioStream *>(get_stream().ptr());
 	if (str == nullptr) {
 		SteamAudio::log(SteamAudio::log_warn,
-				"Tried to get an inner stream from a SteamAudioPlayer, but its outer stream is not a SteamAudioStream. Returning null.");
+						"Tried to get an inner stream from a SteamAudioPlayer, but its outer stream is not a SteamAudioStream. Returning null.");
 		Ref<AudioStream> null_str;
 		return null_str;
 	}
@@ -298,7 +301,7 @@ Ref<AudioStreamPlayback> SteamAudioPlayer::get_inner_stream_playback() {
 	auto spb = dynamic_cast<SteamAudioStreamPlayback *>(get_stream_playback().ptr());
 	if (spb == nullptr) {
 		SteamAudio::log(SteamAudio::log_warn,
-				"Tried to get an inner stream playback from a SteamAudioPlayer, but its outer stream playback is not a SteamAudioStreamPlayback (or the player may not be playing audio). Returning null.");
+						"Tried to get an inner stream playback from a SteamAudioPlayer, but its outer stream playback is not a SteamAudioStreamPlayback (or the player may not be playing audio). Returning null.");
 		Ref<AudioStreamPlayback> null_pb;
 		return null_pb;
 	}
@@ -337,6 +340,9 @@ bool SteamAudioPlayer::is_reflection_on() { return cfg.is_reflection_on; }
 void SteamAudioPlayer::set_reflection_on(bool p_reflection_on) { cfg.is_reflection_on = p_reflection_on; }
 bool SteamAudioPlayer::is_occlusion_on() { return cfg.is_occlusion_on; }
 void SteamAudioPlayer::set_occlusion_on(bool p_occlusion_on) { cfg.is_occlusion_on = p_occlusion_on; }
+
+IPLTransmissionType SteamAudioPlayer::get_transmission_type() { return cfg.transmission_type; }
+void SteamAudioPlayer::set_transmission_type(IPLTransmissionType p_transmission_type) { cfg.transmission_type = p_transmission_type; }
 
 PackedStringArray SteamAudioPlayer::_get_configuration_warnings() const {
 	PackedStringArray res;

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -34,7 +34,8 @@ private:
 		IPLAirAbsorptionModelType::IPL_AIRABSORPTIONTYPE_DEFAULT,
 		true,
 		true,
-		false
+		false,
+		IPLTransmissionType::IPL_TRANSMISSIONTYPE_FREQDEPENDENT
 	};
 
 	LocalSteamAudioState local_state;
@@ -89,6 +90,9 @@ public:
 
 	bool is_occlusion_on();
 	void set_occlusion_on(bool p_occlusion_on);
+
+	IPLTransmissionType get_transmission_type();
+	void set_transmission_type(IPLTransmissionType p_transmission_type);
 
 	void play_stream(const Ref<AudioStream> &p_stream, float p_from_offset, float p_volume_db, float p_pitch_scale);
 	Ref<AudioStream> get_inner_stream();

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -11,6 +11,7 @@
 using namespace godot;
 
 VARIANT_ENUM_CAST(IPLAirAbsorptionModelType);
+VARIANT_ENUM_CAST(IPLTransmissionType);
 
 class SteamAudio {
 public:
@@ -58,6 +59,7 @@ struct SteamAudioSourceConfig {
 	bool is_ambisonics_on;
 	bool is_occlusion_on;
 	bool is_reflection_on;
+	IPLTransmissionType transmission_type;
 };
 
 struct SteamAudioEffects {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -96,6 +96,7 @@ int32_t SteamAudioStreamPlayback::_mix(AudioFrame *buffer, float rate_scale, int
 				ls->direct_outputs.flags |
 				IPL_DIRECTEFFECTFLAGS_APPLYOCCLUSION |
 				IPL_DIRECTEFFECTFLAGS_APPLYTRANSMISSION);
+		ls->direct_outputs.transmissionType = ls->cfg.transmission_type;
 	}
 
 	if (ls->direct_outputs.flags != 0) {


### PR DESCRIPTION
## Problem

Transmission through walls only reduces volume uniformly — there's no frequency-based muffling. A sound behind a thick concrete wall sounds quieter but not muffled, which breaks immersion.

This happens because `transmissionType` on `IPLDirectEffectParams` is never set, so it defaults to `IPL_TRANSMISSIONTYPE_FREQINDEPENDENT`. In this mode, Steam Audio averages the 3-band transmission coefficients (low/mid/high) into a single scalar gain. The per-band values from materials (e.g. concrete: `low=0.015, mid=0.002, high=0.001`) are computed by the simulation but thrown away at the application step.

Fixes #117

## Solution

Set `transmissionType` on `IPLDirectEffectParams` to enable Steam Audio's per-band EQ path in `iplDirectEffectApply()`. This is exposed as a new `transmission_type` property on `SteamAudioPlayer` with two options: Frequency-Independent (old behavior) and Frequency-Dependent (new default).

The default is `Frequency-Dependent` so existing scenes get the improved behavior without changes. Users can switch back to `Frequency-Independent` per player in the inspector if desired.

## Notes

- The 4 indentation changes in `player.cpp` are from clang-format fixing pre-existing style violations
- All changes pass clang-format with the project's config

## Testing

Tested manually in a multi-room scene with walls, floors, and interactive doors. With `Frequency-Dependent` enabled, sounds through walls are noticeably muffled (high frequencies attenuated more than low). Opening/closing doors produces a clear audible difference in tone, not just volume.