### PR TITLE
Add directivity modeling to SteamAudioPlayer

### DIFF
--- a/project/scenes/directivity_showcase.tscn
+++ b/project/scenes/directivity_showcase.tscn
@@ -1,0 +1,262 @@
+[gd_scene format=3 uid="uid://dq7t4x3nab2kp"]
+
+[ext_resource type="AudioStream" uid="uid://ca6667b63t1vv" path="res://sound/pluck1.mp3" id="beep_sound"]
+[ext_resource type="Script" uid="uid://bsuex25ycqs6d" path="res://src/player.gd" id="player_script"]
+[ext_resource type="Script" uid="uid://b4h9jw6mn3c2t" path="res://src/directivity_showcase.gd" id="showcase_script"]
+[ext_resource type="Script" uid="uid://c5r8n2t7j1qvx" path="res://src/directivity_speaker.gd" id="dir_speaker_script"]
+[ext_resource type="Script" uid="uid://bwvolbm6jpfyo" path="res://src/cone_visualizer.gd" id="cone_vis_script"]
+
+[sub_resource type="PhysicalSkyMaterial" id="sky_mat"]
+
+[sub_resource type="Sky" id="sky"]
+sky_material = SubResource("sky_mat")
+
+[sub_resource type="Environment" id="env"]
+background_mode = 2
+sky = SubResource("sky")
+ambient_light_source = 3
+reflected_light_source = 2
+
+[sub_resource type="BoxShape3D" id="shape_ground"]
+size = Vector3(40, 0.2, 30)
+
+[sub_resource type="StandardMaterial3D" id="mat_ground"]
+albedo_color = Color(0.25, 0.22, 0.18, 1)
+
+[sub_resource type="BoxMesh" id="mesh_ground"]
+material = SubResource("mat_ground")
+size = Vector3(40, 0.2, 30)
+
+[sub_resource type="StandardMaterial3D" id="mat_speaker"]
+albedo_color = Color(0.07, 0.07, 0.07, 1)
+
+[sub_resource type="BoxMesh" id="mesh_speaker_box"]
+material = SubResource("mat_speaker")
+size = Vector3(0.5, 0.7, 0.35)
+
+[sub_resource type="StandardMaterial3D" id="mat_stand"]
+albedo_color = Color(0.3, 0.3, 0.3, 1)
+
+[sub_resource type="CylinderMesh" id="mesh_stand"]
+material = SubResource("mat_stand")
+top_radius = 0.04
+bottom_radius = 0.04
+height = 1.5
+
+[sub_resource type="CapsuleShape3D" id="shape_player"]
+
+[node name="DirectivityShowcase" type="Node3D"]
+script = ExtResource("showcase_script")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("env")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(0.0283352, -0.959332, 0.280855, 0.280166, 0.277328, 0.919019, -0.959533, 0.0526454, 0.27663, 0, 9, 0)
+shadow_enabled = true
+
+[node name="SteamAudioConfig" type="SteamAudioConfig" parent="."]
+scene_type = 0
+
+[node name="Ground" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Ground"]
+shape = SubResource("shape_ground")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]
+mesh = SubResource("mesh_ground")
+
+[node name="Speakers" type="Node3D" parent="."]
+
+[node name="Speaker0" type="SteamAudioPlayer" parent="Speakers"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, -12, 1.5, 0)
+stream = ExtResource("beep_sound")
+distance_attenuation = true
+autoplay = false
+
+[node name="DirectivitySpeaker" type="Node" parent="Speakers/Speaker0"]
+script = ExtResource("dir_speaker_script")
+dipole_weight = 0.0
+dipole_power = 1.0
+proximity_radius = 5.0
+
+[node name="ConeVisualizer" type="MeshInstance3D" parent="Speakers/Speaker0"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.5, 0)
+script = ExtResource("cone_vis_script")
+dipole_weight = 0.0
+dipole_power = 1.0
+max_radius = 4.0
+color = Color(0.85, 0.85, 0.85, 0.55)
+
+[node name="SpeakerBox" type="MeshInstance3D" parent="Speakers/Speaker0"]
+mesh = SubResource("mesh_speaker_box")
+
+[node name="Stand" type="MeshInstance3D" parent="Speakers/Speaker0"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1, 0)
+mesh = SubResource("mesh_stand")
+
+[node name="Label3D" type="Label3D" parent="Speakers/Speaker0"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 1.2, 0)
+text = "Omnidirectional
+w=0.0"
+font_size = 48
+outline_size = 8
+billboard = 1
+
+[node name="Speaker1" type="SteamAudioPlayer" parent="Speakers"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, -4, 1.5, 0)
+stream = ExtResource("beep_sound")
+distance_attenuation = true
+autoplay = false
+
+[node name="DirectivitySpeaker" type="Node" parent="Speakers/Speaker1"]
+script = ExtResource("dir_speaker_script")
+dipole_weight = 0.3
+dipole_power = 1.5
+proximity_radius = 5.0
+
+[node name="ConeVisualizer" type="MeshInstance3D" parent="Speakers/Speaker1"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.5, 0)
+script = ExtResource("cone_vis_script")
+dipole_weight = 0.3
+dipole_power = 1.5
+max_radius = 4.0
+color = Color(0.0, 0.9, 1.0, 0.55)
+
+[node name="SpeakerBox" type="MeshInstance3D" parent="Speakers/Speaker1"]
+mesh = SubResource("mesh_speaker_box")
+
+[node name="Stand" type="MeshInstance3D" parent="Speakers/Speaker1"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1, 0)
+mesh = SubResource("mesh_stand")
+
+[node name="Label3D" type="Label3D" parent="Speakers/Speaker1"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 1.2, 0)
+text = "Wide Cardioid
+w=0.3"
+font_size = 48
+outline_size = 8
+billboard = 1
+
+[node name="Speaker2" type="SteamAudioPlayer" parent="Speakers"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 4, 1.5, 0)
+stream = ExtResource("beep_sound")
+distance_attenuation = true
+autoplay = false
+
+[node name="DirectivitySpeaker" type="Node" parent="Speakers/Speaker2"]
+script = ExtResource("dir_speaker_script")
+dipole_weight = 0.5
+dipole_power = 2.0
+proximity_radius = 5.0
+
+[node name="ConeVisualizer" type="MeshInstance3D" parent="Speakers/Speaker2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.5, 0)
+script = ExtResource("cone_vis_script")
+dipole_weight = 0.5
+dipole_power = 2.0
+max_radius = 4.0
+color = Color(0.2, 1.0, 0.3, 0.55)
+
+[node name="SpeakerBox" type="MeshInstance3D" parent="Speakers/Speaker2"]
+mesh = SubResource("mesh_speaker_box")
+
+[node name="Stand" type="MeshInstance3D" parent="Speakers/Speaker2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1, 0)
+mesh = SubResource("mesh_stand")
+
+[node name="Label3D" type="Label3D" parent="Speakers/Speaker2"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 1.2, 0)
+text = "Cardioid
+w=0.5"
+font_size = 48
+outline_size = 8
+billboard = 1
+
+[node name="Speaker3" type="SteamAudioPlayer" parent="Speakers"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 12, 1.5, 0)
+stream = ExtResource("beep_sound")
+distance_attenuation = true
+autoplay = false
+
+[node name="DirectivitySpeaker" type="Node" parent="Speakers/Speaker3"]
+script = ExtResource("dir_speaker_script")
+dipole_weight = 0.75
+dipole_power = 3.0
+proximity_radius = 5.0
+
+[node name="ConeVisualizer" type="MeshInstance3D" parent="Speakers/Speaker3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.5, 0)
+script = ExtResource("cone_vis_script")
+dipole_weight = 0.75
+dipole_power = 3.0
+max_radius = 4.0
+color = Color(1.0, 0.6, 0.0, 0.55)
+
+[node name="SpeakerBox" type="MeshInstance3D" parent="Speakers/Speaker3"]
+mesh = SubResource("mesh_speaker_box")
+
+[node name="Stand" type="MeshInstance3D" parent="Speakers/Speaker3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.1, 0)
+mesh = SubResource("mesh_stand")
+
+[node name="Label3D" type="Label3D" parent="Speakers/Speaker3"]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 1.2, 0)
+text = "Hypercardioid
+w=0.75"
+font_size = 48
+outline_size = 8
+billboard = 1
+
+[node name="Player" type="CharacterBody3D" parent="." groups=["player"] node_paths=PackedStringArray("cam")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 8)
+script = ExtResource("player_script")
+cam = NodePath("Camera3D")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Player"]
+shape = SubResource("shape_player")
+
+[node name="Camera3D" type="Camera3D" parent="Player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.6, 0)
+
+[node name="SteamAudioListener" type="SteamAudioListener" parent="Player/Camera3D"]
+
+[node name="UI" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Instructions" type="RichTextLabel" parent="UI"]
+layout_mode = 1
+offset_right = 320.0
+offset_bottom = 160.0
+bbcode_enabled = true
+text = "[b]Directivity Showcase[/b]
+
+[WASD] Move    [Mouse] Look
+[Esc] Toggle cursor
+
+Walk up to each speaker.
+Move [b]behind[/b] it — sound cuts off!
+Each speaker has a different pattern."
+fit_content = true
+scroll_active = false
+
+[node name="ModeLabel" type="RichTextLabel" parent="UI"]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -280.0
+offset_top = 12.0
+offset_right = 280.0
+offset_bottom = 60.0
+grow_horizontal = 2
+bbcode_enabled = true
+text = "[b][T]  Directivity:  [color=#44ff88]ON[/color][/b]"
+fit_content = true
+scroll_active = false

--- a/project/src/cone_visualizer.gd
+++ b/project/src/cone_visualizer.gd
@@ -1,0 +1,63 @@
+## Renders a polar directivity diagram on the ground around the speaker.
+## Shape matches the actual Steam Audio directivity formula:
+##   factor = |(1 - dipole_weight) + dipole_weight * cos(angle)|^dipole_power
+## Forward direction = speaker's local -Z axis.
+extends MeshInstance3D
+
+@export var dipole_weight: float = 0.0
+@export var dipole_power: float = 1.0
+@export var max_radius: float = 4.0
+@export var color: Color = Color(0.8, 0.8, 0.8, 0.55)
+@export var segments: int = 128
+
+func _ready() -> void:
+	var arr_mesh := _build_mesh()
+	var mat := StandardMaterial3D.new()
+	mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	mat.vertex_color_use_as_albedo = true
+	mat.cull_mode = BaseMaterial3D.CULL_DISABLED
+	mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	mat.no_depth_test = false
+	arr_mesh.surface_set_material(0, mat)
+	mesh = arr_mesh
+
+func _directivity(angle_rad: float) -> float:
+	var d := (1.0 - dipole_weight) + dipole_weight * cos(angle_rad)
+	return pow(maxf(d, 0.0), dipole_power)
+
+func _build_mesh() -> ArrayMesh:
+	var verts := PackedVector3Array()
+	var cols := PackedColorArray()
+	var indices := PackedInt32Array()
+
+	# Raise slightly above ground to avoid z-fighting
+	const Y := 0.02
+
+	# Center vertex — slightly dimmer
+	verts.append(Vector3(0.0, Y, 0.0))
+	cols.append(Color(color.r, color.g, color.b, color.a * 0.25))
+
+	for i in range(segments + 1):
+		var angle := (float(i) / float(segments)) * TAU
+		var factor := _directivity(angle)
+		var r := factor * max_radius
+		# angle=0 → straight ahead = speaker's local -Z
+		var x := sin(angle) * r
+		var z := -cos(angle) * r
+		verts.append(Vector3(x, Y, z))
+		cols.append(Color(color.r, color.g, color.b, factor * color.a))
+
+	for i in range(segments):
+		indices.append(0)
+		indices.append(i + 1)
+		indices.append(i + 2)
+
+	var arr := Array()
+	arr.resize(Mesh.ARRAY_MAX)
+	arr[Mesh.ARRAY_VERTEX] = verts
+	arr[Mesh.ARRAY_COLOR] = cols
+	arr[Mesh.ARRAY_INDEX] = indices
+
+	var arr_mesh := ArrayMesh.new()
+	arr_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arr)
+	return arr_mesh

--- a/project/src/cone_visualizer.gd.uid
+++ b/project/src/cone_visualizer.gd.uid
@@ -1,0 +1,1 @@
+uid://bwvolbm6jpfyo

--- a/project/src/directivity_showcase.gd
+++ b/project/src/directivity_showcase.gd
@@ -1,0 +1,29 @@
+extends Node3D
+
+@onready var mode_label: RichTextLabel = $UI/ModeLabel
+
+var speakers: Array = []
+var directivity_on: bool = true
+
+func _ready() -> void:
+	speakers = [
+		$Speakers/Speaker0,
+		$Speakers/Speaker1,
+		$Speakers/Speaker2,
+		$Speakers/Speaker3,
+	]
+	_update_hud()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.pressed and not event.echo:
+		if event.keycode == KEY_T:
+			directivity_on = !directivity_on
+			for spk in speakers:
+				spk.set("directivity", directivity_on)
+			_update_hud()
+
+func _update_hud() -> void:
+	if directivity_on:
+		mode_label.text = "[b][T]  Directivity:  [color=#44ff88]ON[/color][/b]"
+	else:
+		mode_label.text = "[b][T]  Directivity:  [color=#ff6644]OFF  —  All speakers omnidirectional[/color][/b]"

--- a/project/src/directivity_showcase.gd.uid
+++ b/project/src/directivity_showcase.gd.uid
@@ -1,0 +1,1 @@
+uid://b4h9jw6mn3c2t

--- a/project/src/directivity_speaker.gd
+++ b/project/src/directivity_speaker.gd
@@ -9,12 +9,12 @@ extends Node
 @export var beep_interval: float = 2.0
 
 var _player_node: Node3D = null
-var _audio: Node3D = null
+var _audio: AudioStreamPlayer3D = null
 var _timer: float = 0.0
 var _next_beep: float = 0.0
 
 func _ready() -> void:
-	_audio = get_parent() as Node3D
+	_audio = get_parent() as AudioStreamPlayer3D
 	_audio.set("directivity", true)
 	_audio.set("dipole_weight", dipole_weight)
 	_audio.set("dipole_power", dipole_power)
@@ -36,5 +36,5 @@ func _process(delta: float) -> void:
 	if _timer >= _next_beep:
 		_timer = 0.0
 		_next_beep = beep_interval + randf_range(-0.4, 0.4)
-		if not _audio.call("is_playing"):
-			_audio.call("play")
+		if not _audio.is_playing():
+			_audio.play()

--- a/project/src/directivity_speaker.gd
+++ b/project/src/directivity_speaker.gd
@@ -1,0 +1,40 @@
+## Attach as a child of a SteamAudioPlayer.
+## Sets directivity properties on the parent and triggers periodic beeps
+## only when the player is within proximity_radius.
+extends Node
+
+@export var dipole_weight: float = 0.0
+@export var dipole_power: float = 1.0
+@export var proximity_radius: float = 5.0
+@export var beep_interval: float = 2.0
+
+var _player_node: Node3D = null
+var _audio: Node3D = null
+var _timer: float = 0.0
+var _next_beep: float = 0.0
+
+func _ready() -> void:
+	_audio = get_parent() as Node3D
+	_audio.set("directivity", true)
+	_audio.set("dipole_weight", dipole_weight)
+	_audio.set("dipole_power", dipole_power)
+	_next_beep = randf_range(0.3, beep_interval)
+
+func _process(delta: float) -> void:
+	if _player_node == null:
+		var nodes := get_tree().get_nodes_in_group("player")
+		if nodes.size() > 0:
+			_player_node = nodes[0] as Node3D
+		if _player_node == null:
+			return
+
+	var dist: float = _audio.global_position.distance_to(_player_node.global_position)
+	if dist > proximity_radius:
+		return
+
+	_timer += delta
+	if _timer >= _next_beep:
+		_timer = 0.0
+		_next_beep = beep_interval + randf_range(-0.4, 0.4)
+		if not _audio.call("is_playing"):
+			_audio.call("play")

--- a/project/src/directivity_speaker.gd.uid
+++ b/project/src/directivity_speaker.gd.uid
@@ -1,0 +1,1 @@
+uid://c5r8n2t7j1qvx

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -33,6 +33,12 @@ void SteamAudioPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_occlusion_on", "p_occlusion_on"), &SteamAudioPlayer::set_occlusion_on);
 	ClassDB::bind_method(D_METHOD("is_reflection_on"), &SteamAudioPlayer::is_reflection_on);
 	ClassDB::bind_method(D_METHOD("set_reflection_on", "p_reflection_on"), &SteamAudioPlayer::set_reflection_on);
+	ClassDB::bind_method(D_METHOD("is_directivity_on"), &SteamAudioPlayer::is_directivity_on);
+	ClassDB::bind_method(D_METHOD("set_directivity_on", "p_directivity_on"), &SteamAudioPlayer::set_directivity_on);
+	ClassDB::bind_method(D_METHOD("get_dipole_weight"), &SteamAudioPlayer::get_dipole_weight);
+	ClassDB::bind_method(D_METHOD("set_dipole_weight", "p_dipole_weight"), &SteamAudioPlayer::set_dipole_weight);
+	ClassDB::bind_method(D_METHOD("get_dipole_power"), &SteamAudioPlayer::get_dipole_power);
+	ClassDB::bind_method(D_METHOD("set_dipole_power", "p_dipole_power"), &SteamAudioPlayer::set_dipole_power);
 	ClassDB::bind_method(D_METHOD("get_occlusion_radius"), &SteamAudioPlayer::get_occlusion_radius);
 	ClassDB::bind_method(D_METHOD("set_occlusion_radius", "p_occlusion_radius"), &SteamAudioPlayer::set_occlusion_radius);
 	ClassDB::bind_method(D_METHOD("get_occlusion_samples"), &SteamAudioPlayer::get_occlusion_samples);
@@ -68,6 +74,11 @@ void SteamAudioPlayer::_bind_methods() {
 	ADD_GROUP("Reflection", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reflection"), "set_reflection_on", "is_reflection_on");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_reflection_distance", PROPERTY_HINT_RANGE, "0.0,20000.0,0.1"), "set_max_reflection_distance", "get_max_reflection_distance");
+
+	ADD_GROUP("Directivity", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "directivity"), "set_directivity_on", "is_directivity_on");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dipole_weight", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_dipole_weight", "get_dipole_weight");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dipole_power", PROPERTY_HINT_RANGE, "0.0,4.0,0.01"), "set_dipole_power", "get_dipole_power");
 }
 
 SteamAudioPlayer::SteamAudioPlayer() {
@@ -253,6 +264,13 @@ void SteamAudioPlayer::process_internal(double delta) {
 	if (is_playing() && !get_stream_playback().is_null()) {
 		pb = get_stream_playback();
 	}
+
+	// Sync cfg changes (e.g. runtime property toggles) into local_state.cfg.
+	// local_state.cfg is a copy made at init time, so setters must be reflected here.
+	if (is_local_state_init.load()) {
+		std::unique_lock lock(local_state.mux);
+		local_state.cfg = cfg;
+	}
 }
 
 void SteamAudioPlayer::play_stream(const Ref<AudioStream> &p_stream, float p_from_offset, float p_volume_db, float p_pitch_scale) {
@@ -343,6 +361,13 @@ void SteamAudioPlayer::set_occlusion_on(bool p_occlusion_on) { cfg.is_occlusion_
 
 IPLTransmissionType SteamAudioPlayer::get_transmission_type() { return cfg.transmission_type; }
 void SteamAudioPlayer::set_transmission_type(IPLTransmissionType p_transmission_type) { cfg.transmission_type = p_transmission_type; }
+
+bool SteamAudioPlayer::is_directivity_on() { return cfg.is_directivity_on; }
+void SteamAudioPlayer::set_directivity_on(bool p_directivity_on) { cfg.is_directivity_on = p_directivity_on; }
+float SteamAudioPlayer::get_dipole_weight() { return cfg.dipole_weight; }
+void SteamAudioPlayer::set_dipole_weight(float p_dipole_weight) { cfg.dipole_weight = p_dipole_weight; }
+float SteamAudioPlayer::get_dipole_power() { return cfg.dipole_power; }
+void SteamAudioPlayer::set_dipole_power(float p_dipole_power) { cfg.dipole_power = p_dipole_power; }
 
 PackedStringArray SteamAudioPlayer::_get_configuration_warnings() const {
 	PackedStringArray res;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -267,7 +267,7 @@ void SteamAudioPlayer::process_internal(double delta) {
 
 	// Sync cfg changes (e.g. runtime property toggles) into local_state.cfg.
 	// local_state.cfg is a copy made at init time, so setters must be reflected here.
-	if (is_local_state_init.load()) {
+	if (is_local_state_init.load() && cfg_dirty.exchange(false)) {
 		std::unique_lock lock(local_state.mux);
 		local_state.cfg = cfg;
 	}
@@ -328,46 +328,46 @@ Ref<AudioStreamPlayback> SteamAudioPlayer::get_inner_stream_playback() {
 }
 
 float SteamAudioPlayer::get_occlusion_radius() { return cfg.occ_radius; }
-void SteamAudioPlayer::set_occlusion_radius(float p_occlusion_radius) { cfg.occ_radius = p_occlusion_radius; }
+void SteamAudioPlayer::set_occlusion_radius(float p_occlusion_radius) { cfg.occ_radius = p_occlusion_radius; cfg_dirty.store(true); }
 int SteamAudioPlayer::get_occlusion_samples() { return cfg.occ_samples; }
-void SteamAudioPlayer::set_occlusion_samples(int p_occlusion_samples) { cfg.occ_samples = p_occlusion_samples; }
+void SteamAudioPlayer::set_occlusion_samples(int p_occlusion_samples) { cfg.occ_samples = p_occlusion_samples; cfg_dirty.store(true); }
 int SteamAudioPlayer::get_transmission_rays() { return cfg.transm_rays; }
-void SteamAudioPlayer::set_transmission_rays(int p_transmission_rays) { cfg.transm_rays = p_transmission_rays; }
+void SteamAudioPlayer::set_transmission_rays(int p_transmission_rays) { cfg.transm_rays = p_transmission_rays; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_min_attenuation_dist() { return cfg.min_attn_dist; }
-void SteamAudioPlayer::set_min_attenuation_dist(float p_min_attenuation_dist) { cfg.min_attn_dist = p_min_attenuation_dist; }
+void SteamAudioPlayer::set_min_attenuation_dist(float p_min_attenuation_dist) { cfg.min_attn_dist = p_min_attenuation_dist; cfg_dirty.store(true); }
 int SteamAudioPlayer::get_ambisonics_order() { return cfg.ambisonics_order; }
-void SteamAudioPlayer::set_ambisonics_order(int p_ambisonics_order) { cfg.ambisonics_order = p_ambisonics_order; }
+void SteamAudioPlayer::set_ambisonics_order(int p_ambisonics_order) { cfg.ambisonics_order = p_ambisonics_order; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_max_reflection_dist() { return cfg.max_refl_dist; }
-void SteamAudioPlayer::set_max_reflection_dist(float p_max_reflection_dist) { cfg.max_refl_dist = p_max_reflection_dist; }
+void SteamAudioPlayer::set_max_reflection_dist(float p_max_reflection_dist) { cfg.max_refl_dist = p_max_reflection_dist; cfg_dirty.store(true); }
 
 bool SteamAudioPlayer::is_dist_attn_on() { return cfg.is_dist_attn_on; }
-void SteamAudioPlayer::set_dist_attn_on(bool p_dist_attn_on) { cfg.is_dist_attn_on = p_dist_attn_on; }
+void SteamAudioPlayer::set_dist_attn_on(bool p_dist_attn_on) { cfg.is_dist_attn_on = p_dist_attn_on; cfg_dirty.store(true); }
 
 bool SteamAudioPlayer::is_air_absorp_on() { return cfg.is_air_absorp_on; }
-void SteamAudioPlayer::set_air_absorp_on(bool p_air_absorp_on) { cfg.is_air_absorp_on = p_air_absorp_on; }
+void SteamAudioPlayer::set_air_absorp_on(bool p_air_absorp_on) { cfg.is_air_absorp_on = p_air_absorp_on; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_air_absorption_low() { return cfg.air_absorption_low; }
-void SteamAudioPlayer::set_air_absorption_low(float p_air_absorption_low) { cfg.air_absorption_low = p_air_absorption_low; }
+void SteamAudioPlayer::set_air_absorption_low(float p_air_absorption_low) { cfg.air_absorption_low = p_air_absorption_low; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_air_absorption_mid() { return cfg.air_absorption_mid; }
-void SteamAudioPlayer::set_air_absorption_mid(float p_air_absorption_mid) { cfg.air_absorption_mid = p_air_absorption_mid; }
+void SteamAudioPlayer::set_air_absorption_mid(float p_air_absorption_mid) { cfg.air_absorption_mid = p_air_absorption_mid; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_air_absorption_high() { return cfg.air_absorption_high; }
-void SteamAudioPlayer::set_air_absorption_high(float p_air_absorption_high) { cfg.air_absorption_high = p_air_absorption_high; }
+void SteamAudioPlayer::set_air_absorption_high(float p_air_absorption_high) { cfg.air_absorption_high = p_air_absorption_high; cfg_dirty.store(true); }
 IPLAirAbsorptionModelType SteamAudioPlayer::get_air_absorption_model_type() { return cfg.air_absorption_model_type; }
-void SteamAudioPlayer::set_air_absorption_model_type(IPLAirAbsorptionModelType p_air_absorption_model_type) { cfg.air_absorption_model_type = p_air_absorption_model_type; }
+void SteamAudioPlayer::set_air_absorption_model_type(IPLAirAbsorptionModelType p_air_absorption_model_type) { cfg.air_absorption_model_type = p_air_absorption_model_type; cfg_dirty.store(true); }
 
 bool SteamAudioPlayer::is_reflection_on() { return cfg.is_reflection_on; }
-void SteamAudioPlayer::set_reflection_on(bool p_reflection_on) { cfg.is_reflection_on = p_reflection_on; }
+void SteamAudioPlayer::set_reflection_on(bool p_reflection_on) { cfg.is_reflection_on = p_reflection_on; cfg_dirty.store(true); }
 bool SteamAudioPlayer::is_occlusion_on() { return cfg.is_occlusion_on; }
-void SteamAudioPlayer::set_occlusion_on(bool p_occlusion_on) { cfg.is_occlusion_on = p_occlusion_on; }
+void SteamAudioPlayer::set_occlusion_on(bool p_occlusion_on) { cfg.is_occlusion_on = p_occlusion_on; cfg_dirty.store(true); }
 
 IPLTransmissionType SteamAudioPlayer::get_transmission_type() { return cfg.transmission_type; }
-void SteamAudioPlayer::set_transmission_type(IPLTransmissionType p_transmission_type) { cfg.transmission_type = p_transmission_type; }
+void SteamAudioPlayer::set_transmission_type(IPLTransmissionType p_transmission_type) { cfg.transmission_type = p_transmission_type; cfg_dirty.store(true); }
 
 bool SteamAudioPlayer::is_directivity_on() { return cfg.is_directivity_on; }
-void SteamAudioPlayer::set_directivity_on(bool p_directivity_on) { cfg.is_directivity_on = p_directivity_on; }
+void SteamAudioPlayer::set_directivity_on(bool p_directivity_on) { cfg.is_directivity_on = p_directivity_on; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_dipole_weight() { return cfg.dipole_weight; }
-void SteamAudioPlayer::set_dipole_weight(float p_dipole_weight) { cfg.dipole_weight = p_dipole_weight; }
+void SteamAudioPlayer::set_dipole_weight(float p_dipole_weight) { cfg.dipole_weight = p_dipole_weight; cfg_dirty.store(true); }
 float SteamAudioPlayer::get_dipole_power() { return cfg.dipole_power; }
-void SteamAudioPlayer::set_dipole_power(float p_dipole_power) { cfg.dipole_power = p_dipole_power; }
+void SteamAudioPlayer::set_dipole_power(float p_dipole_power) { cfg.dipole_power = p_dipole_power; cfg_dirty.store(true); }
 
 PackedStringArray SteamAudioPlayer::_get_configuration_warnings() const {
 	PackedStringArray res;

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -44,6 +44,7 @@ private:
 	LocalSteamAudioState local_state;
 	std::atomic<bool> is_local_state_init;
 	std::atomic<bool> can_load_local_state;
+	std::atomic<bool> cfg_dirty{false};
 	bool has_warned_panning = false;
 	bool has_warned_attenuation = false;
 

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -35,7 +35,10 @@ private:
 		true,
 		true,
 		false,
-		IPLTransmissionType::IPL_TRANSMISSIONTYPE_FREQDEPENDENT
+		IPLTransmissionType::IPL_TRANSMISSIONTYPE_FREQDEPENDENT,
+		false,
+		0.0f,
+		1.0f
 	};
 
 	LocalSteamAudioState local_state;
@@ -93,6 +96,13 @@ public:
 
 	IPLTransmissionType get_transmission_type();
 	void set_transmission_type(IPLTransmissionType p_transmission_type);
+
+	bool is_directivity_on();
+	void set_directivity_on(bool p_directivity_on);
+	float get_dipole_weight();
+	void set_dipole_weight(float p_dipole_weight);
+	float get_dipole_power();
+	void set_dipole_power(float p_dipole_power);
 
 	void play_stream(const Ref<AudioStream> &p_stream, float p_from_offset, float p_volume_db, float p_pitch_scale);
 	Ref<AudioStream> get_inner_stream();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -56,11 +56,7 @@ void SteamAudioServer::tick() {
 		absorp_model.coefficients[1] = ls->cfg.air_absorption_mid;
 		absorp_model.coefficients[2] = ls->cfg.air_absorption_high;
 
-		IPLCoordinateSpace3 src_coords;
-		src_coords.ahead = IPLVector3{};
-		src_coords.up = IPLVector3{};
-		src_coords.right = IPLVector3{};
-		src_coords.origin = ipl_vec3_from(src_pos);
+		IPLCoordinateSpace3 src_coords = ipl_coords_from(ls->src.player->get_global_transform());
 
 		IPLSimulationInputs inputs{};
 		inputs.flags = IPL_SIMULATIONFLAGS_DIRECT;
@@ -88,6 +84,13 @@ void SteamAudioServer::tick() {
 					inputs.directFlags |
 					IPL_DIRECTSIMULATIONFLAGS_OCCLUSION |
 					IPL_DIRECTSIMULATIONFLAGS_TRANSMISSION);
+		}
+		if (ls->cfg.is_directivity_on) {
+			inputs.directivity.dipoleWeight = ls->cfg.dipole_weight;
+			inputs.directivity.dipolePower = ls->cfg.dipole_power;
+			inputs.directFlags = static_cast<IPLDirectSimulationFlags>(
+					inputs.directFlags |
+					IPL_DIRECTSIMULATIONFLAGS_DIRECTIVITY);
 		}
 
 		SteamAudio::log(SteamAudio::log_debug, "tick: setting inputs");
@@ -162,12 +165,7 @@ void SteamAudioServer::tick() {
 			continue;
 		}
 
-		Vector3 src_pos = ls->src.player->get_global_position();
-		IPLCoordinateSpace3 src_coords;
-		src_coords.ahead = IPLVector3{};
-		src_coords.up = IPLVector3{};
-		src_coords.right = IPLVector3{};
-		src_coords.origin = ipl_vec3_from(src_pos);
+		IPLCoordinateSpace3 src_coords = ipl_coords_from(ls->src.player->get_global_transform());
 
 		IPLSimulationInputs inputs{};
 		inputs.flags = IPL_SIMULATIONFLAGS_REFLECTIONS;

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -60,6 +60,9 @@ struct SteamAudioSourceConfig {
 	bool is_occlusion_on;
 	bool is_reflection_on;
 	IPLTransmissionType transmission_type;
+	bool is_directivity_on;
+	float dipole_weight;
+	float dipole_power;
 };
 
 struct SteamAudioEffects {

--- a/src/steam_audio.hpp
+++ b/src/steam_audio.hpp
@@ -100,7 +100,7 @@ inline int ambisonic_channels_from(int order) {
 
 inline IPLVector3 ipl_vec3_from(Vector3 v) { return IPLVector3{ v.x, v.y, v.z }; }
 
-inline IPLCoordinateSpace3 ipl_coords_from(Transform3D trf) {
+inline IPLCoordinateSpace3 ipl_coords_from(const Transform3D &trf) {
 	auto orig = trf.origin;
 	auto right = trf.get_basis().get_column(0);
 	auto up = trf.get_basis().get_column(1);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -98,6 +98,11 @@ int32_t SteamAudioStreamPlayback::_mix(AudioFrame *buffer, float rate_scale, int
 				IPL_DIRECTEFFECTFLAGS_APPLYTRANSMISSION);
 		ls->direct_outputs.transmissionType = ls->cfg.transmission_type;
 	}
+	if (ls->cfg.is_directivity_on) {
+		ls->direct_outputs.flags = static_cast<IPLDirectEffectFlags>(
+				ls->direct_outputs.flags |
+				IPL_DIRECTEFFECTFLAGS_APPLYDIRECTIVITY);
+	}
 
 	if (ls->direct_outputs.flags != 0) {
 		iplDirectEffectApply(


### PR DESCRIPTION
Closes #124. Partially addresses #105.

## Summary

Implements `IPLDirectivity` to give `SteamAudioPlayer` nodes a directional sound pattern. Sources now emit audio in a configurable cone — a speaker facing away from the listener becomes significantly quieter or silent.

## New inspector properties on SteamAudioPlayer

| Property | Type | Range | Description |
|---|---|---|---|
| `directivity` | bool | — | Enable directivity simulation |
| `dipole_weight` | float | 0–1 | 0 = omni, 0.5 = cardioid, 1.0 = figure-8 |
| `dipole_power` | float | 0–4 | Sharpness of the falloff cone |

Steam Audio computes the directivity factor at angle θ as:
`|(1 − dipole_weight) + dipole_weight × cos(θ)|^dipole_power`

## Changes

### New feature
- Add `directivity`, `dipole_weight`, `dipole_power` properties to the inspector
- Pass `IPL_DIRECTSIMULATIONFLAGS_DIRECTIVITY` and source directivity in `server.cpp` tick
- Apply `IPL_DIRECTEFFECTFLAGS_APPLYDIRECTIVITY` in `stream.cpp` mix

### Bug fixes
- **Fix source coordinate orientation**: `IPLCoordinateSpace3` for sources previously had zeroed `ahead`/`up`/`right` vectors. Now correctly derives orientation from the node's global transform via `ipl_coords_from()`.
- **Fix runtime property changes not taking effect** (partially addresses #105): `local_state.cfg` was a one-time copy of `cfg` made at init. Fixed by syncing `cfg → local_state.cfg` each process tick under the existing mutex.

### Demo scene
Added `project/scenes/directivity_showcase.tscn` — four speakers with different patterns (omni, wide cardioid, cardioid, hypercardioid), polar diagrams on the ground, and proximity-triggered audio. Press T to toggle directivity on/off.

<img width="1460" height="785" alt="Screenshot 2026-03-09 at 1 05 06 AM" src="https://github.com/user-attachments/assets/fa44f1b3-1f2d-4b52-b75f-40627cdb4cdd" />